### PR TITLE
take_one - generic over `T: ?Sized`

### DIFF
--- a/src/helper.rs
+++ b/src/helper.rs
@@ -56,7 +56,7 @@ pub fn numerify_sym(string: &str) -> String {
 }
 
 #[inline]
-pub fn take_one<'a>(list: &[&'a str]) -> &'a str {
+pub fn take_one<'a, T: ?Sized>(list: &[&'a T]) -> &'a T {
     let mut rng = thread_rng();
     list.choose(&mut rng).expect("take_one got empty list")
 }


### PR DESCRIPTION
Maybe it's also a good idea to Re-export `rand`, if somebody wants to use `thread_rng`