### PR TITLE
feat: ratio for Option<T> WIP

### DIFF
--- a/fake/src/faker/mod.rs
+++ b/fake/src/faker/mod.rs
@@ -71,6 +71,12 @@ pub mod boolean {
     }
 }
 
+pub mod option {
+    def_fakers! {
+        Opt(ratio: u8);
+    }
+}
+
 #[cfg(feature = "chrono")]
 pub mod chrono {
     def_fakers! {

--- a/fake/src/impls/std/option.rs
+++ b/fake/src/impls/std/option.rs
@@ -1,13 +1,15 @@
-use crate::{Dummy, Fake, Faker};
+use crate::Dummy;
+use crate::faker::boolean::en::*;
+use crate::faker::option::raw::Opt;
 use rand::Rng;
 
-impl<T, U> Dummy<U> for Option<T>
+impl<T, U> Dummy<Opt<U>> for Option<T>
 where
     T: Dummy<U>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &U, rng: &mut R) -> Self {
-        if Faker.fake_with_rng::<bool, _>(rng) {
-            Some(T::dummy_with_rng(config, rng))
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &Opt<U>, rng: &mut R) -> Self {
+        if bool::dummy_with_rng(&Boolean(config.1), rng) {
+            Some(T::dummy_with_rng(&config.0, rng))
         } else {
             None
         }


### PR DESCRIPTION
`Option<T>` is something like `Boolean` (it has `Some(T)` value or `None`). So I'd like to use ratio for this. But now we have a 50:50 ratio (look at percentage on 1 screenshot). \
I have a code something like this:
```rust
    let mut rng = rand::thread_rng();
    let file = File::create("data.csv")?;
    let mut wtr = csv::Writer::from_writer(file);
    let mut i = 0;
    let rows = rng.gen_range(10000..100000);
    loop {
        wtr.serialize(Faker.fake::<Foo>())?;
        if i == rows {
            break;
        }
        i += 1;
    }
    wtr.flush()?;
```

Current behavior - we have 50:50 ration:
![pic1](https://user-images.githubusercontent.com/24863565/114278368-2b494400-9a38-11eb-9335-0267f05b1751.png)

After this commit:
![pic2](https://user-images.githubusercontent.com/24863565/114278371-2d130780-9a38-11eb-8318-30eb928e46a8.png)

P.S. Of course to start it working we should add `#[dummy(faker = 'Opt((), 98)')` to our struct's members like this
```rust
    #[dummy(faker = "Opt(0..2000, 93)")]
    order_id: Option<u64>,
    #[dummy(faker = "Opt(0..2000, 81)")]
    make_id: Option<u64>,
    #[dummy(faker = "Opt(0..2000, 98)")]
    time_id: Option<u64>,
    #[dummy(faker = "Opt(0..2000, 90)")]
    this_id: Option<u64>,
    #[dummy(faker = "Opt(0.0..2000.0, 78)")]
    my_float: Option<f64>,
```
