### PR TITLE
Don't require chrono's default features

### DIFF
--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 dummy = { version = "0.4", path = "../dummy_derive", optional = true }
 rand = "0.8"
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4", features = ["std"], optional = true, default-features = false }
 http = { version = "0.2", optional = true }
 semver = { version = "1", optional = true }
 uuid = { version = "0.8", features = ["v1", "v3", "v4", "v5"], optional = true }

--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -19,6 +19,7 @@ semver = { version = "1", optional = true }
 uuid = { version = "0.8", features = ["v1", "v3", "v4", "v5"], optional = true }
 
 [dev-dependencies]
+chrono = { version = "0.4", features = ["clock"], default-features = false }
 fake = { path = ".", features = ["derive"] }
 proptest = "1.0.0"
 rand_chacha = "0.3"


### PR DESCRIPTION
This removes an unneccessary dependency on time 0.1