### PR TITLE
time: add chrono alternative with time lib

### DIFF
--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { version = "0.4", features = ["std"], optional = true, default-feature
 http = { version = "0.2", optional = true }
 semver = { version = "1", optional = true }
 uuid = { version = "0.8", features = ["v1", "v3", "v4", "v5"], optional = true }
+time = { version = "0.3", features = ["formatting"], optional = true }
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["clock"], default-features = false }

--- a/fake/src/faker/impls/mod.rs
+++ b/fake/src/faker/impls/mod.rs
@@ -5,8 +5,8 @@ mod barecode;
 mod boolean;
 #[cfg(feature = "chrono")]
 mod chrono;
-mod creditcard;
 mod company;
+mod creditcard;
 mod currency;
 mod filesystem;
 mod finance;
@@ -18,3 +18,5 @@ mod lorem;
 mod name;
 mod number;
 mod phone_number;
+#[cfg(feature = "time")]
+mod time;

--- a/fake/src/faker/impls/time.rs
+++ b/fake/src/faker/impls/time.rs
@@ -1,0 +1,126 @@
+use crate::faker::time::raw::*;
+use crate::locales::Data;
+use crate::{Dummy, Fake, Faker};
+use rand::Rng;
+
+const MINUTES_MAX_BOUND: i64 = 1_000_000;
+
+impl<L: Data> Dummy<Time<L>> for time::Time {
+    #[inline]
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Time<L>, rng: &mut R) -> Self {
+        Faker.fake_with_rng(rng)
+    }
+}
+
+impl<L: Data> Dummy<Time<L>> for String {
+    #[inline]
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Time<L>, rng: &mut R) -> Self {
+        let time: time::Time = Faker.fake_with_rng(rng);
+        time.format(&time::format_description::parse(L::TIME_DEFAULT_TIME_FORMAT).unwrap())
+            .unwrap()
+    }
+}
+
+impl<L: Data> Dummy<Date<L>> for time::Date {
+    #[inline]
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Date<L>, rng: &mut R) -> Self {
+        Faker.fake_with_rng(rng)
+    }
+}
+
+impl<L: Data> Dummy<Date<L>> for String {
+    #[inline]
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Date<L>, rng: &mut R) -> Self {
+        let date: time::Date = Faker.fake_with_rng(rng);
+        date.format(&time::format_description::parse(L::TIME_DEFAULT_DATE_FORMAT).unwrap())
+            .unwrap()
+    }
+}
+
+impl<L: Data> Dummy<DateTime<L>> for time::PrimitiveDateTime {
+    #[inline]
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
+        Faker.fake_with_rng(rng)
+    }
+}
+
+impl<L: Data> Dummy<DateTime<L>> for time::OffsetDateTime {
+    #[inline]
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
+        Faker.fake_with_rng(rng)
+    }
+}
+
+impl<L: Data> Dummy<DateTime<L>> for String {
+    #[inline]
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
+        let datetime: time::OffsetDateTime = Faker.fake_with_rng(rng);
+        datetime
+            .format(&time::format_description::parse(L::TIME_DEFAULT_DATETIME_FORMAT).unwrap())
+            .unwrap()
+    }
+}
+
+impl<L: Data> Dummy<Duration<L>> for time::Duration {
+    #[inline]
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Duration<L>, rng: &mut R) -> Self {
+        Faker.fake_with_rng(rng)
+    }
+}
+
+impl<L: Data> Dummy<DateTimeBefore<L>> for time::OffsetDateTime {
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeBefore<L>, rng: &mut R) -> Self {
+        let mins: i64 = (1..MINUTES_MAX_BOUND).fake_with_rng(rng);
+        let duration = time::Duration::minutes(mins);
+        c.1 - duration
+    }
+}
+
+impl<L: Data> Dummy<DateTimeBefore<L>> for String {
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeBefore<L>, rng: &mut R) -> Self {
+        let datetime: time::OffsetDateTime = c.fake_with_rng(rng);
+        datetime
+            .format(&time::format_description::parse(L::TIME_DEFAULT_DATETIME_FORMAT).unwrap())
+            .unwrap()
+    }
+}
+
+impl<L: Data> Dummy<DateTimeAfter<L>> for time::OffsetDateTime {
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeAfter<L>, rng: &mut R) -> Self {
+        let mins: i64 = (1..MINUTES_MAX_BOUND).fake_with_rng(rng);
+        let duration = time::Duration::minutes(mins);
+        c.1 + duration
+    }
+}
+
+impl<L: Data> Dummy<DateTimeAfter<L>> for String {
+    #[inline]
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeAfter<L>, rng: &mut R) -> Self {
+        let datetime: time::OffsetDateTime = c.fake_with_rng(rng);
+        datetime
+            .format(&time::format_description::parse(L::TIME_DEFAULT_DATETIME_FORMAT).unwrap())
+            .unwrap()
+    }
+}
+
+impl<L: Data> Dummy<DateTimeBetween<L>> for time::OffsetDateTime {
+    #[inline]
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeBetween<L>, rng: &mut R) -> Self {
+        let diff = c.2 - c.1;
+        let max_minutes = diff.whole_minutes();
+
+        let from_start: i64 = (0..max_minutes).fake_with_rng(rng);
+        let duration = time::Duration::minutes(from_start);
+        c.1 + duration
+    }
+}
+
+impl<L: Data> Dummy<DateTimeBetween<L>> for String {
+    #[inline]
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeBetween<L>, rng: &mut R) -> Self {
+        let datetime: time::OffsetDateTime = c.fake_with_rng(rng);
+        datetime
+            .format(&time::format_description::parse(L::TIME_DEFAULT_DATETIME_FORMAT).unwrap())
+            .unwrap()
+    }
+}

--- a/fake/src/faker/mod.rs
+++ b/fake/src/faker/mod.rs
@@ -94,6 +94,19 @@ pub mod chrono {
     }
 }
 
+#[cfg(feature = "time")]
+pub mod time {
+    def_fakers! {
+        Time();
+        Date();
+        DateTime();
+        Duration();
+        DateTimeBefore(dt: time::OffsetDateTime);
+        DateTimeAfter(dt: time::OffsetDateTime);
+        DateTimeBetween(start: time::OffsetDateTime, end: time::OffsetDateTime);
+    }
+}
+
 pub mod creditcard {
     def_fakers! {
         CreditCardNumber();
@@ -127,19 +140,19 @@ pub mod http {
 
 pub mod internet {
     def_fakers! {
-        FreeEmailProvider();
-        DomainSuffix();
-        FreeEmail();
-        SafeEmail();
-        Username();
-        Password(len_range: std::ops::Range<usize>);
-        IPv4();
-        IPv6();
-        IP();
-        MACAddress();
-        Color();
-        UserAgent();
-      }
+      FreeEmailProvider();
+      DomainSuffix();
+      FreeEmail();
+      SafeEmail();
+      Username();
+      Password(len_range: std::ops::Range<usize>);
+      IPv4();
+      IPv6();
+      IP();
+      MACAddress();
+      Color();
+      UserAgent();
+    }
 }
 
 pub mod job {

--- a/fake/src/impls/mod.rs
+++ b/fake/src/impls/mod.rs
@@ -4,9 +4,10 @@
 pub mod chrono;
 #[cfg(feature = "http")]
 pub mod http;
-pub mod std;
 #[cfg(feature = "semver")]
 pub mod semver;
+pub mod std;
+#[cfg(feature = "time")]
+pub mod time;
 #[cfg(feature = "uuid")]
 pub mod uuid;
-

--- a/fake/src/impls/time/mod.rs
+++ b/fake/src/impls/time/mod.rs
@@ -1,0 +1,56 @@
+use crate::{Dummy, Fake, Faker};
+use rand::Rng;
+use time::{Date, Duration, OffsetDateTime, PrimitiveDateTime, Time};
+
+const YEAR_MAG: i32 = 3_000i32;
+const MIN_NANOS: i128 = -377_705_116_800_000_000_000;
+const MAX_NANOS: i128 = 253_402_300_799_000_000_000;
+
+fn is_leap(year: i32) -> bool {
+    if year % 400 == 0 {
+        true
+    } else if year % 100 == 0 {
+        false
+    } else {
+        year % 4 == 0
+    }
+}
+
+impl Dummy<Faker> for Duration {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        Duration::nanoseconds(Faker.fake_with_rng(rng))
+    }
+}
+
+impl Dummy<Faker> for OffsetDateTime {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let nanos = (MIN_NANOS..MAX_NANOS).fake_with_rng(rng);
+        OffsetDateTime::from_unix_timestamp_nanos(nanos).unwrap()
+    }
+}
+
+impl Dummy<Faker> for Date {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let year: i32 = (0..YEAR_MAG).fake_with_rng(rng);
+        let end = if is_leap(year) { 366 } else { 365 };
+        let day_ord: u16 = (1..end).fake_with_rng(rng);
+        Date::from_ordinal_date(year, day_ord).unwrap()
+    }
+}
+
+impl Dummy<Faker> for Time {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let hour = (0..24).fake_with_rng(rng);
+        let min = (0..60).fake_with_rng(rng);
+        let sec = (0..60).fake_with_rng(rng);
+        Time::from_hms(hour, min, sec).unwrap()
+    }
+}
+
+impl Dummy<Faker> for PrimitiveDateTime {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let date = Faker.fake_with_rng(rng);
+        let time = Faker.fake_with_rng(rng);
+        PrimitiveDateTime::new(date, time)
+    }
+}

--- a/fake/src/locales/mod.rs
+++ b/fake/src/locales/mod.rs
@@ -69,6 +69,12 @@ pub trait Data {
     const CHRONO_DEFAULT_DATE_FORMAT: &'static str = "%F";
     const CHRONO_DEFAULT_DATETIME_FORMAT: &'static str = "%+";
 
+    // see https://time-rs.github.io/book/api/format-description.html
+    // for a complete description of each format
+    const TIME_DEFAULT_TIME_FORMAT: &'static str = "[hour]:[minute]:[second][subsecond]";
+    const TIME_DEFAULT_DATE_FORMAT: &'static str = "[year]-[month]-[day]";
+    const TIME_DEFAULT_DATETIME_FORMAT: &'static str = "[year]-[month]-[day]T[hour]:[minute]:[second][offset_hour sign:mandatory][offset_minute]";
+
     const PATH_ROOT_DIRS: &'static [&'static str] = &[ "/", "/etc", "/home", "/bin", "/sbin", "/usr", "/tmp", "/var"];
     const PATH_SEGMENTS:  &'static [&'static str] = &["time", "person", "year", "way", "day", "thing", "man", "world", "life", "hand", "part", "child", "eye", "woman", "place", "work", "week", "case", "point", "government", "company", "number", "group", "problem", "fact", "good", "new", "first", "last", "long", "great", "little", "own", "other", "old", "right", "big", "high", "different", "small", "large", "next", "early", "young", "important", "few", "public", "bad", "same", "able", "olivia", "liam", "emma", "noah", "ava", "elijah", "sophia", "oliver", "isabella", "lucas", "amelia", "mason", "mia", "logan", "charlotte", "ethan", "harper", "james", "aria", "jackson"];
     const PATH_EXTENSIONS: &'static [&'static str] = &["so", "mp3", "mp4", "flv", "jpg", "png", "txt", "csv", "doc", "xls", "ppt", "zip", "rar", "7z", "tar"];

--- a/fake/tests/determinism.proptest-regressions
+++ b/fake/tests/determinism.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 80cb724b8d19dc0198d031478ad13085f26c7d08f1b637caa46a6f9624dba0d9 # shrinks to seed = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/fake/tests/determinism.rs
+++ b/fake/tests/determinism.rs
@@ -108,6 +108,29 @@ mod chrono {
     check_determinism! { l10d Time; String, fake_time_en, fake_time_fr, fake_time_cn, fake_time_tw, fake_time_jp }
 }
 
+// time
+#[cfg(feature = "time")]
+mod time {
+    use fake::{faker::time::raw::*, locales::*, Fake};
+    use rand::SeedableRng as _;
+
+    fn lo() -> time::OffsetDateTime {
+        time::OffsetDateTime::from_unix_timestamp(53469346924).unwrap()
+    }
+
+    fn hi() -> time::OffsetDateTime {
+        lo() + time::Duration::days(365)
+    }
+
+    check_determinism! { l10d Date; String, fake_date_en, fake_date_fr, fake_date_cn, fake_date_tw, fake_date_jp }
+    check_determinism! { l10d DateTime; String, fake_date_time_en, fake_date_time_fr, fake_date_time_cn, fake_date_time_tw, fake_date_time_jp }
+    check_determinism! { l10d DateTimeAfter; String, fake_date_time_after_en, fake_date_time_after_fr, fake_date_time_after_cn, fake_date_time_after_tw, fake_date_time_after_jp, lo() }
+    check_determinism! { l10d DateTimeBefore; String, fake_date_time_before_en, fake_date_time_before_fr, fake_date_time_before_cn, fake_date_time_before_tw, fake_date_time_before_jp, hi() }
+    check_determinism! { l10d DateTimeBetween; String, fake_date_time_between_en, fake_date_time_between_fr, fake_date_time_between_cn, fake_date_time_between_tw, fake_date_time_between_jp, lo(), hi() }
+    check_determinism! { l10d Duration; ::time::Duration, fake_duration_en, fake_duration_fr, fake_duration_cn, fake_duration_tw, fake_duration_jp }
+    check_determinism! { l10d Time; String, fake_time_en, fake_time_fr, fake_time_cn, fake_time_tw, fake_time_jp }
+}
+
 // Company
 use fake::faker::company::raw::*;
 


### PR DESCRIPTION
Hey, thank you for the awesome library!

as you probably know, chrono is abandonned, and while the best alternative is still not completely decided, time looks like a good candidate.

This PR adds the `time` feature. It's mostly copy paste at this point, and there are a couple of unwraps lying around.
Happy to change anything you don't like.
I'm thinking of adding decimal support as well at some point.