### PR TITLE
[Scout] Add determinism to decimal

### DIFF
--- a/fake/src/impls/decimal/mod.rs
+++ b/fake/src/impls/decimal/mod.rs
@@ -19,8 +19,8 @@ impl Dummy<Faker> for rust_decimal::Decimal {
 }
 
 impl Dummy<Decimal> for rust_decimal::Decimal {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Decimal, _: &mut R) -> Self {
-            Faker.fake()
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Decimal, rng: &mut R) -> Self {
+            Faker.fake_with_rng(rng)
     }
 }
 
@@ -49,7 +49,7 @@ impl Dummy<PositiveDecimal> for rust_decimal::Decimal {
 }
 
 impl Dummy<NoDecimalPoints> for rust_decimal::Decimal {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &NoDecimalPoints, _: &mut R) -> Self {
-        Faker.fake::<rust_decimal::Decimal>().round_dp(0)
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &NoDecimalPoints, rng: &mut R) -> Self {
+        Faker.fake_with_rng::<rust_decimal::Decimal, R>(rng).round_dp(0)
     }
 }

--- a/fake/tests/determinism.rs
+++ b/fake/tests/determinism.rs
@@ -270,3 +270,17 @@ use fake::faker::phone_number::raw::*;
 
 check_determinism! { l10d CellNumber; String, fake_cell_number_en, fake_cell_number_fr, fake_cell_number_cn, fake_cell_number_tw, fake_cell_number_jp }
 check_determinism! { l10d PhoneNumber; String, fake_phone_number_en, fake_phone_number_fr, fake_phone_number_cn, fake_phone_number_tw, fake_phone_number_jp }
+
+// Decimal
+#[cfg(feature = "rust_decimal")]
+mod decimal {
+    use fake::decimal::*;
+    use rust_decimal as rs;
+    use fake::Fake;
+    use rand::SeedableRng as _;
+
+    check_determinism! { Decimal; default, rs::Decimal }
+    check_determinism! { NegativeDecimal; negative_decimal, rs::Decimal }
+    check_determinism! { PositiveDecimal; positive_decimal, rs::Decimal }
+    check_determinism! { NoDecimalPoints; no_decimal_points, rs::Decimal }
+}


### PR DESCRIPTION
As per request of @mothsART  in my [previous PR](https://github.com/cksac/fake-rs/pull/80), here are determinsm tests added to the Decimal fake types.