### PR TITLE
accents (ie : éàça) isn't support on mail providers

### DIFF
--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 dummy = { version = "0.4", path = "../dummy_derive", optional = true }
 rand = "0.8"
 random_color = { version="0.6", optional = true }
+unidecode = "0.3"
 chrono = { version = "0.4", features = ["std"], optional = true, default-features = false }
 chrono-tz = { version = "0.6", optional = true }
 http = { version = "0.2", optional = true }

--- a/fake/src/faker/impls/internet.rs
+++ b/fake/src/faker/impls/internet.rs
@@ -3,6 +3,7 @@ use crate::faker::lorem::raw::Word;
 use crate::faker::name::raw::FirstName;
 use crate::locales::{Data, EN};
 use crate::{Dummy, Fake, Faker};
+use unidecode::unidecode;
 use rand::distributions::{Distribution, Uniform};
 use rand::seq::SliceRandom;
 use rand::Rng;
@@ -38,7 +39,7 @@ impl<L: Data + Copy> Dummy<FreeEmail<L>> for String {
     fn dummy_with_rng<R: Rng + ?Sized>(c: &FreeEmail<L>, rng: &mut R) -> Self {
         let username: String = Username(c.0).fake_with_rng(rng);
         let provider: String = FreeEmailProvider(c.0).fake_with_rng(rng);
-        format!("{}@{}", username, provider)
+        format!("{}@{}", unidecode(&username), provider)
     }
 }
 


### PR DESCRIPTION
mails in non english format (like french) used accent username to form mail but this is not correct : mail providers works in ascii.