### PR TITLE
Typo BareCode -> Barcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Geohash(precision: u8);
 LicencePlate();
 ```
 
-### BareCode
+### Barcode
 ```rust
 Isbn();
 Isbn13();


### PR DESCRIPTION
Fixed a typo in the README.md file where a subheading was named `BareCode`. Changed the typo to Barcode.