### PR TITLE
Fixed typo barecode -> barcode

### DIFF
--- a/fake/examples/fakers.rs
+++ b/fake/examples/fakers.rs
@@ -426,8 +426,8 @@ fn creditcard_faker() {
     println!("{:?}", val);
 }
 
-fn barecode_faker() {
-    use fake::faker::barecode::raw::*;
+fn barcode_faker() {
+    use fake::faker::barcode::raw::*;
 
     let val: String = Isbn13(EN).fake();
     println!("{}", val);
@@ -493,7 +493,7 @@ fn main() {
     filesystem_faker();
     currency_faker();
     creditcard_faker();
-    barecode_faker();
+    barcode_faker();
 
     #[cfg(feature = "random_color")]
     color_faker();

--- a/fake/src/faker/impls/barcode.rs
+++ b/fake/src/faker/impls/barcode.rs
@@ -1,18 +1,18 @@
-use crate::faker::barecode::raw::*;
+use crate::faker::barcode::raw::*;
 use crate::faker::boolean::raw::Boolean;
 use crate::faker::numerify_sym;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
-use rand::Rng;
 use rand::prelude::SliceRandom;
+use rand::Rng;
 
-const ISBN_MAX_LENGTH:usize = 13;
+const ISBN_MAX_LENGTH: usize = 13;
 
 struct IsbnProperties {
     ean: &'static str,
     group: &'static str,
     registrant: String,
-    publication: String
+    publication: String,
 }
 
 impl IsbnProperties {
@@ -23,10 +23,7 @@ impl IsbnProperties {
         }
         format!(
             "{}{}{}{}",
-            ean,
-            self.group,
-            self.registrant,
-            self.publication
+            ean, self.group, self.registrant, self.publication
         )
     }
 }
@@ -75,12 +72,12 @@ fn checksum13(properties: &IsbnProperties) -> i32 {
 fn get_properties<L: Data, R: Rng + ?Sized>(_c: L, rng: &mut R) -> IsbnProperties {
     let ean = L::ISBN_EAN;
     let rules = *L::isbn_rules();
-    let keys:Vec<&'static str> = rules.keys().cloned().collect();
+    let keys: Vec<&'static str> = rules.keys().cloned().collect();
     let group = keys.choose(rng).unwrap();
-    
+
     let reg_pub_len = ISBN_MAX_LENGTH - ean.chars().count() - group.chars().count() - 1;
     let reg_pub = numerify_sym(&"#".repeat(reg_pub_len), rng);
-    
+
     let mut reg_len = 0;
     let sufix_reg_pub = &reg_pub[..reg_pub_len as usize - 1];
 
@@ -93,8 +90,8 @@ fn get_properties<L: Data, R: Rng + ?Sized>(_c: L, rng: &mut R) -> IsbnPropertie
     IsbnProperties {
         ean,
         group,
-        registrant:  reg_pub[..reg_len as usize].to_string(),
-        publication: reg_pub[reg_len as usize..reg_pub_len as usize].to_string()
+        registrant: reg_pub[..reg_len as usize].to_string(),
+        publication: reg_pub[reg_len as usize..reg_pub_len as usize].to_string(),
     }
 }
 

--- a/fake/src/faker/impls/mod.rs
+++ b/fake/src/faker/impls/mod.rs
@@ -1,12 +1,12 @@
 mod address;
 mod administrative;
 mod automotive;
-mod barecode;
+mod barcode;
 mod boolean;
-#[cfg(feature = "random_color")]
-mod color;
 #[cfg(feature = "chrono")]
 mod chrono;
+#[cfg(feature = "random_color")]
+mod color;
 mod company;
 mod creditcard;
 mod currency;

--- a/fake/src/faker/mod.rs
+++ b/fake/src/faker/mod.rs
@@ -67,7 +67,7 @@ pub mod address {
     }
 }
 
-pub mod barecode {
+pub mod barcode {
     def_fakers! {
         Isbn();
         Isbn10();

--- a/fake/tests/determinism.rs
+++ b/fake/tests/determinism.rs
@@ -76,7 +76,7 @@ use fake::faker::automotive::raw::*;
 check_determinism! { one fake_license_plate_fr, String, LicencePlate(FR_FR) }
 
 // Barcode
-use fake::faker::barecode::raw::*;
+use fake::faker::barcode::raw::*;
 
 check_determinism! { l10d Isbn; String, fake_isbn_en, fake_isbn_fr, fake_isbn_cn, fake_isbn_tw, fake_isbn_jp }
 check_determinism! { l10d Isbn10; String, fake_isbn10_en, fake_isbn10_fr, fake_isbn10_cn, fake_isbn10_tw, fake_isbn10_jp }
@@ -275,9 +275,9 @@ check_determinism! { l10d PhoneNumber; String, fake_phone_number_en, fake_phone_
 #[cfg(feature = "rust_decimal")]
 mod decimal {
     use fake::decimal::*;
-    use rust_decimal as rs;
     use fake::Fake;
     use rand::SeedableRng as _;
+    use rust_decimal as rs;
 
     check_determinism! { Decimal; default, rs::Decimal }
     check_determinism! { NegativeDecimal; negative_decimal, rs::Decimal }


### PR DESCRIPTION
Fixed a typo within the source code where barecode was used instead of `barcode`.

The fix affects the module's name so it will break all current users that implement the `barecode` code.

I did a quick search on github for `barecode language:Rust` and `use crate::fake::barcode::raw::*;` on Google and neither turn up any projects using the function that was changed.

Might be best to fix this typo now rather than later when other projects might break.