### PR TITLE
Add support for `bigdecimal-rs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ If you want `rust_decimal` faker features:
 ```toml
 fake = { version = "2.4", features=['rust_decimal']}
 ```
+If you want `bigdecimal` faker features:
+```toml
+fake = { version = "2.4", features=['bigdecimal']}
+```
 If you want `random_color` faker features:
 ```toml
 fake = { version = "2.4", features=['random_color']}

--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -20,6 +20,7 @@ semver = { version = "1", optional = true }
 uuid = { version = "0.8", features = ["v1", "v3", "v4", "v5"], optional = true }
 time = { version = "0.3", features = ["formatting"], optional = true }
 rust_decimal = { version = "1.23", optional = true }
+bigdecimal_rs = { version = "0.3.0", package = "bigdecimal", optional = true }
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["clock"], default-features = false }
@@ -30,6 +31,7 @@ rand_chacha = "0.3"
 [features]
 # Provide derive(Dummy) macros.
 derive = ["dummy"]
+bigdecimal = ["bigdecimal_rs", "rust_decimal"]
 
 [[example]]
 name = "basic"

--- a/fake/examples/fakers.rs
+++ b/fake/examples/fakers.rs
@@ -479,6 +479,28 @@ fn decimal_faker() {
     println!("{:?}", val);
 }
 
+#[cfg(feature = "bigdecimal")]
+fn bigdecimal_faker() {
+    use bigdecimal_rs as bd;
+    use fake::bigdecimal::*;
+    use fake::Faker;
+
+    let val: bd::BigDecimal = Faker.fake();
+    println!("{:?}", val);
+
+    let val: bd::BigDecimal = BigDecimal.fake();
+    println!("{:?}", val);
+
+    let val: bd::BigDecimal = PositiveBigDecimal.fake();
+    println!("{:?}", val);
+
+    let val: bd::BigDecimal = NegativeBigDecimal.fake();
+    println!("{:?}", val);
+
+    let val: bd::BigDecimal = NoBigDecimalPoints.fake();
+    println!("{:?}", val);
+}
+
 fn main() {
     lorem_faker();
     name_faker();
@@ -509,4 +531,7 @@ fn main() {
 
     #[cfg(feature = "rust_decimal")]
     decimal_faker();
+
+    #[cfg(feature = "bigdecimal")]
+    bigdecimal_faker();
 }

--- a/fake/src/impls/bigdecimal/mod.rs
+++ b/fake/src/impls/bigdecimal/mod.rs
@@ -1,0 +1,51 @@
+use crate::decimal::*;
+use crate::{Dummy, Fake, Faker};
+use bigdecimal_rs as bd;
+use rand::Rng;
+use rust_decimal;
+use std::str::FromStr;
+
+pub struct BigDecimal;
+pub struct NegativeBigDecimal;
+pub struct PositiveBigDecimal;
+pub struct NoBigDecimalPoints;
+
+impl Dummy<Faker> for bd::BigDecimal {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let decimal: rust_decimal::Decimal = Faker.fake_with_rng(rng);
+
+        bd::BigDecimal::from_str(&decimal.to_string()).unwrap()
+    }
+}
+
+impl Dummy<BigDecimal> for bd::BigDecimal {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &BigDecimal, rng: &mut R) -> Self {
+        let decimal: rust_decimal::Decimal = Decimal.fake_with_rng(rng);
+
+        bd::BigDecimal::from_str(&decimal.to_string()).unwrap()
+    }
+}
+
+impl Dummy<NegativeBigDecimal> for bd::BigDecimal {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &NegativeBigDecimal, rng: &mut R) -> Self {
+        let decimal: rust_decimal::Decimal = NegativeDecimal.fake_with_rng(rng);
+
+        bd::BigDecimal::from_str(&decimal.to_string()).unwrap()
+    }
+}
+
+impl Dummy<PositiveBigDecimal> for bd::BigDecimal {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &PositiveBigDecimal, rng: &mut R) -> Self {
+        let decimal: rust_decimal::Decimal = PositiveDecimal.fake_with_rng(rng);
+
+        bd::BigDecimal::from_str(&decimal.to_string()).unwrap()
+    }
+}
+
+impl Dummy<NoBigDecimalPoints> for bd::BigDecimal {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &NoBigDecimalPoints, rng: &mut R) -> Self {
+        let decimal: rust_decimal::Decimal = NoDecimalPoints.fake_with_rng(rng);
+
+        bd::BigDecimal::from_str(&decimal.to_string()).unwrap()
+    }
+}

--- a/fake/src/impls/mod.rs
+++ b/fake/src/impls/mod.rs
@@ -1,9 +1,11 @@
 //! This module contains implementations of `Dummy` trait
 
-#[cfg(feature = "random_color")]
-pub mod color;
+#[cfg(feature = "bigdecimal")]
+pub mod bigdecimal;
 #[cfg(feature = "chrono")]
 pub mod chrono;
+#[cfg(feature = "random_color")]
+pub mod color;
 #[cfg(feature = "rust_decimal")]
 pub mod decimal;
 #[cfg(feature = "http")]

--- a/fake/src/lib.rs
+++ b/fake/src/lib.rs
@@ -210,6 +210,9 @@ pub use impls::uuid;
 #[cfg(feature = "rust_decimal")]
 pub use impls::decimal;
 
+#[cfg(feature = "bigdecimal")]
+pub use impls::bigdecimal;
+
 /// Fake value generation for specific formats.
 ///
 /// It is structured in a way such that the modules here describes the custom

--- a/fake/tests/determinism.rs
+++ b/fake/tests/determinism.rs
@@ -284,3 +284,17 @@ mod decimal {
     check_determinism! { PositiveDecimal; positive_decimal, rs::Decimal }
     check_determinism! { NoDecimalPoints; no_decimal_points, rs::Decimal }
 }
+
+// BigDecimal
+#[cfg(feature = "bigdecimal")]
+mod bigdecimal {
+    use bigdecimal_rs as bd;
+    use fake::bigdecimal::*;
+    use fake::Fake;
+    use rand::SeedableRng as _;
+
+    check_determinism! { BigDecimal; default, bd::BigDecimal }
+    check_determinism! { NegativeBigDecimal; negative_decimal, bd::BigDecimal }
+    check_determinism! { PositiveBigDecimal; positive_decimal, bd::BigDecimal }
+    check_determinism! { NoBigDecimalPoints; no_decimal_points, bd::BigDecimal }
+}


### PR DESCRIPTION
Even if I want to use `rust_decimal` module, my current project use `bigdecimal-rs` as dependency. So I added the `bigdecimal` impls to the lib (which shamelessly use current `rust_decimal` module 😭).