### PR TITLE
Feat better dummy

### DIFF
--- a/dummy_derive/src/lib.rs
+++ b/dummy_derive/src/lib.rs
@@ -34,6 +34,8 @@ struct DummyField {
     faker: Option<String>,
     #[darling(default)]
     fixed: Option<String>,
+    #[darling(default)]
+    default: bool,
 }
 
 #[derive(Debug, FromDeriveInput)]
@@ -205,7 +207,11 @@ pub fn hello_world(input: TokenStream) -> TokenStream {
 }
 
 fn expose_field(f: &DummyField) -> proc_macro2::TokenStream {
-    if let Some(ref expr) = f.fixed {
+    if f.default {
+        quote!{
+            Default::default()
+        }
+    } else if let Some(ref expr) = f.fixed {
         let fixed = syn::parse_str::<syn::Expr>(expr).unwrap();
         quote!{
             #fixed

--- a/fake/examples/derive.rs
+++ b/fake/examples/derive.rs
@@ -70,6 +70,22 @@ enum Message {
 }
 
 #[derive(Debug, Dummy)]
+struct FixedStruct {
+    #[dummy(faker = "1..100")]
+    pub product_id: usize,
+    #[dummy(fixed = "\"Base\".into()")]
+    pub fixed_value: String,
+}
+
+#[derive(Debug, Dummy)]
+struct DefaultStruct {
+    #[dummy(faker = "1..100")]
+    pub product_id: usize,
+    #[dummy(default)]
+    pub fixed_value: String,
+}
+
+#[derive(Debug, Dummy)]
 struct UnitStruct;
 
 #[derive(Debug, Dummy)]
@@ -101,5 +117,11 @@ fn main() {
     println!("{:#?}", v);
 
     let v: uuid::Uuid = Faker.fake();
+    println!("{:#?}", v);
+
+    let v: FixedStruct = Faker.fake();
+    println!("{:#?}", v);
+
+    let v: DefaultStruct = Faker.fake();
     println!("{:#?}", v);
 }

--- a/fake/tests/derive_macros.rs
+++ b/fake/tests/derive_macros.rs
@@ -11,144 +11,312 @@ fn rng() -> rand_chacha::ChaCha20Rng {
     rand_chacha::ChaCha20Rng::from_seed(seed)
 }
 
-#[test]
-fn enum_type() {
-    #[derive(Dummy, Debug, Eq, PartialEq)]
-    enum MyEnum {
-        One,
-        Two,
+mod field_options {
+    use super::*;
+
+    mod enum_type {
+        use super::*;
+
+        #[test]
+        fn no_overrides() {
+            #[derive(Dummy, Debug, Eq, PartialEq)]
+            enum MyEnum {
+                One,
+                Two,
+            }
+
+            let o: MyEnum = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o, MyEnum::Two);
+        }
+
+        #[test]
+        #[should_panic(expected = "can not create an empty enum")]
+        fn with_no_variants() {
+            #[derive(Dummy, Debug, Eq, PartialEq)]
+            enum MyEnum {}
+
+            let _o: MyEnum = Faker.fake_with_rng(&mut rng());
+        }
+
+        #[test]
+        fn with_tuple() {
+            #[derive(Dummy, Debug, Eq, PartialEq)]
+            enum MyEnum {
+                One,
+                Two(
+                    #[dummy(faker = "1..100")] i32,
+                    #[dummy(default)] i32,
+                    #[dummy(fixed = "1")] i32,
+                ),
+            }
+
+            let o: MyEnum = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o, MyEnum::Two(89, 0, 1));
+        }
+
+        #[test]
+        fn with_struct() {
+            #[derive(Dummy, Debug, Eq, PartialEq)]
+            enum MyEnum {
+                One,
+                Two {
+                    #[dummy(faker = "1..100")]
+                    x: i32,
+                    #[dummy(default)]
+                    y: i32,
+                    #[dummy(fixed = "1")]
+                    z: i32,
+                },
+            }
+
+            let o: MyEnum = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o, MyEnum::Two { x: 89, y: 0, z: 1 });
+        }
     }
 
-    let o: MyEnum = Faker.fake_with_rng(&mut rng());
+    mod unit_struct {
+        use super::*;
 
-    assert_eq!(o, MyEnum::Two);
-}
+        #[test]
+        fn no_overrides() {
+            #[derive(Dummy)]
+            struct Obj;
 
-#[test]
-fn struct_no_overrides() {
-    #[derive(Dummy)]
-    struct Obj {
-        pub name: String,
+            let _o: Obj = Faker.fake_with_rng(&mut rng());
+
+            // nothing to really assert other than it compiles and runs
+        }
     }
 
-    let o: Obj = Faker.fake_with_rng(&mut rng());
+    mod tuple_struct {
+        use super::*;
 
-    assert_eq!(o.name, "5KuGzxfjPN9Ha");
-}
+        #[test]
+        fn no_overrides() {
+            #[derive(Dummy)]
+            struct Obj(i32);
 
-#[test]
-fn struct_with_override_range() {
-    #[derive(Dummy)]
-    struct Obj {
-        #[dummy(faker = "(100..200)")]
-        pub id: i32,
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.0, -1377781642);
+        }
+
+        #[test]
+        fn override_range() {
+            #[derive(Dummy)]
+            struct Obj(
+                #[dummy(faker = "100..200")]
+                i32
+            );
+
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.0, 156);
+        }
+
+        #[test]
+        fn with_enum() {
+            #[derive(Dummy, Debug, Eq, PartialEq)]
+            enum MyEnum {
+                One,
+                Two,
+            }
+            #[derive(Dummy)]
+            struct Obj(
+                MyEnum,
+            );
+
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.0, MyEnum::Two);
+        }
+
+        #[test]
+        fn with_default() {
+            #[derive(Dummy)]
+            struct Obj(
+                #[dummy(default)]
+                String,
+            );
+
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.0, "");
+        }
+
+        #[test]
+        fn with_override_faker() {
+            #[derive(Dummy)]
+            struct Obj(
+                #[dummy(faker = "fake::faker::name::en::Name()")]
+                String,
+            );
+
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.0, "Marietta Maggio");
+        }
+
+        #[test]
+        fn with_override_fixed_i32() {
+            #[derive(Dummy)]
+            struct Obj(
+                #[dummy(fixed = "42")]
+                i32,
+            );
+
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.0, 42);
+        }
     }
 
-    let o: Obj = Faker.fake_with_rng(&mut rng());
+    mod struct_type {
+        use super::*;
 
-    assert_eq!(o.id, 156);
-}
+        #[test]
+        fn no_overrides() {
+            #[derive(Dummy)]
+            struct Obj {
+                pub name: String,
+            }
 
-#[test]
-fn struct_with_override_faker() {
-    #[derive(Dummy)]
-    struct Obj {
-        #[dummy(faker = "fake::faker::name::en::Name()")]
-        pub name: String,
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.name, "5KuGzxfjPN9Ha");
+        }
+
+        #[test]
+        fn with_override_range() {
+            #[derive(Dummy)]
+            struct Obj {
+                #[dummy(faker = "100..200")]
+                pub id: i32,
+            }
+
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.id, 156);
+        }
+
+        #[test]
+        fn with_override_faker() {
+            #[derive(Dummy)]
+            struct Obj {
+                #[dummy(faker = "fake::faker::name::en::Name()")]
+                pub name: String,
+            }
+
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.name, "Marietta Maggio");
+        }
+
+        #[test]
+        fn with_enum() {
+            #[derive(Dummy, Debug, Eq, PartialEq)]
+            enum MyEnum {
+                One,
+                Two,
+            }
+            #[derive(Dummy)]
+            struct Obj {
+                pub value: MyEnum,
+            }
+
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.value, MyEnum::Two);
+        }
+
+        #[test]
+        fn with_default() {
+            #[derive(Dummy)]
+            struct Obj {
+                #[dummy(default)]
+                pub value: String,
+            }
+
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.value, "");
+        }
+
+        #[test]
+        fn with_override_fixed_i32() {
+            #[derive(Dummy)]
+            struct Obj {
+                #[dummy(fixed = "42")]
+                pub value: i32,
+            }
+
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.value, 42);
+        }
+
+        #[test]
+        fn with_override_fixed_string() {
+            #[derive(Dummy)]
+            struct Obj {
+                #[dummy(fixed = "\"My string\".into()")]
+                pub value: String,
+            }
+
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.value, "My string");
+        }
+
+        #[test]
+        fn with_override_fixed_from_fn() {
+            fn my_default() -> String {
+                "My String".into()
+            }
+            #[derive(Dummy)]
+            struct Obj {
+                #[dummy(fixed = "my_default()")]
+                pub value: String,
+            }
+
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.value, my_default());
+        }
+
+        #[test]
+        fn with_override_fixed_str() {
+            #[derive(Dummy)]
+            struct Obj {
+                #[dummy(fixed = "\"My string\"")]
+                pub value: &'static str,
+            }
+
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.value, "My string");
+        }
+
+        #[test]
+        #[allow(dead_code)]
+        fn with_override_fixed_enum() {
+            #[derive(Eq, PartialEq, Debug)]
+            enum MyEnum {
+                One,
+                Two,
+            }
+            #[derive(Dummy)]
+            struct Obj {
+                #[dummy(fixed = "MyEnum::One")]
+                pub value: MyEnum,
+            }
+
+            let o: Obj = Faker.fake_with_rng(&mut rng());
+
+            assert_eq!(o.value, MyEnum::One);
+        }
     }
-
-    let o: Obj = Faker.fake_with_rng(&mut rng());
-
-    assert_eq!(o.name, "Marietta Maggio");
-}
-
-#[test]
-fn struct_with_enum() {
-    #[derive(Dummy, Debug, Eq, PartialEq)]
-    enum MyEnum {
-        One,
-        Two,
-    }
-    #[derive(Dummy)]
-    struct Obj {
-        pub value: MyEnum,
-    }
-
-    let o: Obj = Faker.fake_with_rng(&mut rng());
-
-    assert_eq!(o.value, MyEnum::Two);
-}
-
-#[test]
-fn struct_with_override_fixed_i32() {
-    #[derive(Dummy)]
-    struct Obj {
-        #[dummy(fixed = "42")]
-        pub value: i32,
-    }
-
-    let o: Obj = Faker.fake_with_rng(&mut rng());
-
-    assert_eq!(o.value, 42);
-}
-
-#[test]
-fn struct_with_override_fixed_string() {
-    #[derive(Dummy)]
-    struct Obj {
-        #[dummy(fixed = "\"My string\".into()")]
-        pub value: String,
-    }
-
-    let o: Obj = Faker.fake_with_rng(&mut rng());
-
-    assert_eq!(o.value, "My string");
-}
-
-#[test]
-fn struct_with_override_fixed_from_fn() {
-    fn my_default() -> String {
-        "My String".into()
-    }
-    #[derive(Dummy)]
-    struct Obj {
-        #[dummy(fixed = "my_default()")]
-        pub value: String,
-    }
-
-    let o: Obj = Faker.fake_with_rng(&mut rng());
-
-    assert_eq!(o.value, my_default());
-}
-
-#[test]
-fn struct_with_override_fixed_str() {
-    #[derive(Dummy)]
-    struct Obj {
-        #[dummy(fixed = "\"My string\"")]
-        pub value: &'static str,
-    }
-
-    let o: Obj = Faker.fake_with_rng(&mut rng());
-
-    assert_eq!(o.value, "My string");
-}
-
-#[test]
-#[allow(dead_code)]
-fn struct_with_override_fixed_enum() {
-    #[derive(Eq, PartialEq, Debug)]
-    enum MyEnum {
-        One,
-        Two,
-    }
-    #[derive(Dummy)]
-    struct Obj {
-        #[dummy(fixed = "MyEnum::One")]
-        pub value: MyEnum,
-    }
-
-    let o: Obj = Faker.fake_with_rng(&mut rng());
-
-    assert_eq!(o.value, MyEnum::One);
 }


### PR DESCRIPTION
@cksac Thanks for merging my other PRs.

As I was using the 'dummy" enhancement PR locally I found a few other niceties and expanded the test.

- this adds a "default" field option as well that will use Default:::default()


```rust
#[derive(Dummy)]
struct Obj(
    #[dummy(default)]
    String,
);
```

<del>
Then the second commit (please let me know if it is ok, or should be named different) adds a derive-level option of default_impl that will generate an impl of the Default trait that will simply call Faker.faker() (helpful for my test only structs)

```rust
#[derive(Dummy)]
#[dummy(default_impl)]
struct Obj {
    pub value: i32,
}

let a : Obj = Default::default();
```
</del>

