### PR TITLE
Add sea orm uuid support

### DIFF
--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -24,6 +24,7 @@ uuid = { version = "1", features = ["v1", "v3", "v4", "v5"], optional = true }
 time = { version = "0.3", features = ["formatting"], optional = true }
 rust_decimal = { version = "1.25", optional = true }
 bigdecimal_rs = { version = "0.3", package = "bigdecimal", optional = true }
+sea-orm = { version = "0.8", optional = true }
 
 
 [dev-dependencies]
@@ -45,7 +46,7 @@ required-features = ["derive"]
 [[example]]
 name = "derive"
 path = "examples/derive.rs"
-required-features = ["derive", "http", "chrono", "uuid", "random_color", "rust_decimal"]
+required-features = ["derive", "http", "chrono", "uuid", "random_color", "rust_decimal", "sea-orm"]
 
 [[example]]
 name = "usage"

--- a/fake/examples/derive.rs
+++ b/fake/examples/derive.rs
@@ -2,10 +2,9 @@ use fake::decimal::*;
 use fake::faker::boolean::en::*;
 use fake::faker::company::en::*;
 use fake::faker::name::en::*;
+use fake::uuid::UUIDv4;
 use fake::Dummy;
 use fake::{Fake, Faker};
-use fake::uuid::UUIDv4;
-
 
 #[derive(Debug, Dummy)]
 pub enum OrderStatus {

--- a/fake/src/impls/mod.rs
+++ b/fake/src/impls/mod.rs
@@ -10,6 +10,8 @@ pub mod color;
 pub mod decimal;
 #[cfg(feature = "http")]
 pub mod http;
+#[cfg(feature = "sea-orm")]
+pub mod sea_orm;
 #[cfg(feature = "semver")]
 pub mod semver;
 pub mod std;

--- a/fake/src/impls/sea_orm/mod.rs
+++ b/fake/src/impls/sea_orm/mod.rs
@@ -1,0 +1,8 @@
+use crate::{Dummy, Fake, Faker};
+use sea_orm::prelude::Uuid;
+
+impl Dummy<Faker> for Uuid {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        Self::from_u128(rng.gen())
+    }
+}


### PR DESCRIPTION
Wanted to use the Dummy derive on a sea-orm model, they have their own UUID. Feedback welcome.