### PR TITLE
Add byteorder dummy

### DIFF
--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -25,7 +25,7 @@ time = { version = "0.3", features = ["formatting"], optional = true }
 rust_decimal = { version = "1.25", optional = true }
 bigdecimal_rs = { version = "0.3", package = "bigdecimal", optional = true }
 sea-orm = { version = "0.8", optional = true }
-
+zerocopy = { version = "0.6", optional = true }
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["clock"], default-features = false }

--- a/fake/src/impls/mod.rs
+++ b/fake/src/impls/mod.rs
@@ -19,5 +19,5 @@ pub mod std;
 pub mod time;
 #[cfg(feature = "uuid")]
 pub mod uuid;
-#[cfg(feature = "zerocopy_byteorder")]
+#[cfg(feature = "zerocopy")]
 pub mod zerocopy_byteorder;

--- a/fake/src/impls/mod.rs
+++ b/fake/src/impls/mod.rs
@@ -19,3 +19,5 @@ pub mod std;
 pub mod time;
 #[cfg(feature = "uuid")]
 pub mod uuid;
+#[cfg(feature = "zerocopy_byteorder")]
+pub mod zerocopy_byteorder;

--- a/fake/src/impls/zerocopy_byteorder/mod.rs
+++ b/fake/src/impls/zerocopy_byteorder/mod.rs
@@ -1,0 +1,26 @@
+use crate::{Dummy, Fake, Faker};
+use rand::Rng;
+use zerocopy::{byteorder, ByteOrder};
+
+macro_rules! byteorder_faker_impl {
+    ($typ:ident) => {
+        impl<O: ByteOrder> Dummy<Faker> for byteorder::$typ<O> {
+            fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+                Self::new(Faker.fake_with_rng(rng))
+            }
+        }
+    };
+}
+
+byteorder_faker_impl!(U16);
+byteorder_faker_impl!(U32);
+byteorder_faker_impl!(U64);
+#[cfg(not(target_os = "emscripten"))]
+byteorder_faker_impl!(U128);
+
+byteorder_faker_impl!(I16);
+byteorder_faker_impl!(I32);
+byteorder_faker_impl!(I64);
+#[cfg(not(target_os = "emscripten"))]
+byteorder_faker_impl!(I128);
+


### PR DESCRIPTION
I found myself creating wrapper types for the various zerocopy::byteorder structs in order to implement the Dummy trait.

I'm not sure if the fake-rs crates wants to contain a local impl for them, but I added one in this PR.  Feel free to use if desired.

If there is a better way to perform this trait implementation, please let me know.