### PR TITLE
Remove hardcoded EN default locale for SafeEmail

### DIFF
--- a/fake/src/faker/impls/internet.rs
+++ b/fake/src/faker/impls/internet.rs
@@ -43,8 +43,8 @@ impl<L: Data + Copy> Dummy<FreeEmail<L>> for String {
 }
 
 impl<L: Data + Copy> Dummy<SafeEmail<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &SafeEmail<L>, rng: &mut R) -> Self {
-        let username: String = FirstName(EN).fake_with_rng::<&str, _>(rng).to_lowercase();
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &SafeEmail<L>, rng: &mut R) -> Self {
+        let username: String = FirstName(c.0).fake_with_rng::<&str, _>(rng).to_lowercase();
         let domain = ["com", "net", "org"].choose(rng).unwrap();
         format!("{}@example.{}", username, domain)
     }


### PR DESCRIPTION
I want to create fake SafeEmail for different locales: ZH_CN, FR_FR (or new additions) for example: 

```
    let val: String = SafeEmail(ZH_CN).fake();
    println!("{:?}", val);
```

This prints us english names, so it is not the desired result.
SafeEmail names appear only in English locale, or the default Data trait implementation. So it would be nice to add support for different locales.