### PR TITLE
Add chrono_tz support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ If you want the date and time features from `chrono`:
 ```toml
 fake = { version = "2.5", features=['chrono']}
 ```
+If you want the timezone features from `chrono-tz`:
+```toml
+fake = { version = "2.5", features=['chrono-tz']}
+```
 If you want `http` faker features:
 ```toml
 fake = { version = "2.5", features=['http']}

--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -18,6 +18,7 @@ dummy = { version = "0.4", path = "../dummy_derive", optional = true }
 rand = "0.8"
 random_color = { version="0.6", optional = true }
 chrono = { version = "0.4", features = ["std"], optional = true, default-features = false }
+chrono-tz = { version = "0.6", optional = true }
 http = { version = "0.2", optional = true }
 semver = { version = "1", optional = true }
 uuid = { version = "1.2", features = ["v1", "v3", "v4", "v5"], optional = true }

--- a/fake/README.md
+++ b/fake/README.md
@@ -21,6 +21,10 @@ If you want the date and time features from `chrono`:
 ```toml
 fake = { version = "2.5", features=['chrono']}
 ```
+If you want the timezone features from `chrono-tz`:
+```toml
+fake = { version = "2.5", features=['chrono-tz']}
+```
 If you want `http` faker features:
 ```toml
 fake = { version = "2.5", features=['http']}

--- a/fake/src/impls/chrono_tz/mod.rs
+++ b/fake/src/impls/chrono_tz/mod.rs
@@ -1,0 +1,21 @@
+use crate::{Dummy, Fake, Faker};
+use chrono_tz::{Tz, TZ_VARIANTS};
+use rand::Rng;
+
+impl Dummy<Faker> for Tz {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let index: usize = (0..TZ_VARIANTS.len()).fake_with_rng(rng);
+        TZ_VARIANTS[index]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dummy_tz() {
+        let tz: Tz = Faker.fake();
+        assert!(TZ_VARIANTS.contains(&tz));
+    }
+}

--- a/fake/src/impls/mod.rs
+++ b/fake/src/impls/mod.rs
@@ -4,6 +4,8 @@
 pub mod bigdecimal;
 #[cfg(feature = "chrono")]
 pub mod chrono;
+#[cfg(feature = "chrono-tz")]
+pub mod chrono_tz;
 #[cfg(feature = "random_color")]
 pub mod color;
 #[cfg(feature = "rust_decimal")]


### PR DESCRIPTION
Add a new feature `chrono-tz` and impl `Dummy` for `chrono_tz::Tz`.

A random timezone is selected from the list of all timezones provided by chrono_tz.

I wasn't sure about the determinism tests, so I skipped them.