### PR TITLE
feat: use fully qualified syntax when calling `fake_with_rng` in derive macro

### DIFF
--- a/dummy_derive/src/lib.rs
+++ b/dummy_derive/src/lib.rs
@@ -68,7 +68,7 @@ pub fn hello_world(input: TokenStream) -> TokenStream {
                 impl_dummy
             }
             ast::Style::Tuple => {
-                let tuple_fields: Vec<_> = fields.iter().map(|f| expose_field(f)).collect();
+                let tuple_fields: Vec<_> = fields.iter().map(expose_field).collect();
 
                 let impl_dummy = quote! {
                     impl fake::Dummy<fake::Faker> for #receiver_name {
@@ -88,7 +88,7 @@ pub fn hello_world(input: TokenStream) -> TokenStream {
                     .map(|f| {
                         let field_name = f.ident.as_ref().unwrap();
                         let field_ty = &f.ty;
-                        let stream = expose_field(&f);
+                        let stream = expose_field(f);
                         quote! {
                             let #field_name: #field_ty = #stream;
                         }
@@ -124,7 +124,7 @@ pub fn hello_world(input: TokenStream) -> TokenStream {
                             }
                             ast::Style::Tuple => {
                                 let tuple_fields: Vec<_> =
-                                    f.fields.fields.iter().map(|f| expose_field(&f)).collect();
+                                    f.fields.fields.iter().map(expose_field).collect();
 
                                 quote! {
                                     #i => {
@@ -147,7 +147,7 @@ pub fn hello_world(input: TokenStream) -> TokenStream {
                                     .map(|f| {
                                         let field_name = f.ident.as_ref().unwrap();
                                         let field_ty = &f.ty;
-                                        let stream = expose_field(&f);
+                                        let stream = expose_field(f);
                                         quote! {
                                             let #field_name: #field_ty = #stream;
                                         }

--- a/dummy_derive/src/lib.rs
+++ b/dummy_derive/src/lib.rs
@@ -68,12 +68,7 @@ pub fn hello_world(input: TokenStream) -> TokenStream {
                 impl_dummy
             }
             ast::Style::Tuple => {
-                let tuple_fields: Vec<_> = fields
-                    .iter()
-                    .map(|f| {
-                        expose_field(f)
-                    })
-                    .collect();
+                let tuple_fields: Vec<_> = fields.iter().map(|f| expose_field(f)).collect();
 
                 let impl_dummy = quote! {
                     impl fake::Dummy<fake::Faker> for #receiver_name {
@@ -128,14 +123,8 @@ pub fn hello_world(input: TokenStream) -> TokenStream {
                                 }
                             }
                             ast::Style::Tuple => {
-                                let tuple_fields: Vec<_> = f
-                                    .fields
-                                    .fields
-                                    .iter()
-                                    .map(|f| {
-                                        expose_field(&f)
-                                    })
-                                    .collect();
+                                let tuple_fields: Vec<_> =
+                                    f.fields.fields.iter().map(|f| expose_field(&f)).collect();
 
                                 quote! {
                                     #i => {
@@ -151,17 +140,19 @@ pub fn hello_world(input: TokenStream) -> TokenStream {
                                     .map(|f| f.ident.as_ref().unwrap())
                                     .collect();
 
-                                let let_statements: Vec<_> = f.fields.fields
-                        .iter()
-                        .map(|f| {
-                            let field_name = f.ident.as_ref().unwrap();
-                            let field_ty = &f.ty;
-                            let stream = expose_field(&f);
-                            quote! {
-                                let #field_name: #field_ty = #stream;
-                            }
-                        })
-                        .collect();
+                                let let_statements: Vec<_> = f
+                                    .fields
+                                    .fields
+                                    .iter()
+                                    .map(|f| {
+                                        let field_name = f.ident.as_ref().unwrap();
+                                        let field_ty = &f.ty;
+                                        let stream = expose_field(&f);
+                                        quote! {
+                                            let #field_name: #field_ty = #stream;
+                                        }
+                                    })
+                                    .collect();
 
                                 quote! {
                                     #i => {
@@ -208,12 +199,12 @@ pub fn hello_world(input: TokenStream) -> TokenStream {
 
 fn expose_field(f: &DummyField) -> proc_macro2::TokenStream {
     if f.default {
-        quote!{
+        quote! {
             Default::default()
         }
     } else if let Some(ref expr) = f.fixed {
         let fixed = syn::parse_str::<syn::Expr>(expr).unwrap();
-        quote!{
+        quote! {
             #fixed
         }
     } else {

--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -27,6 +27,8 @@ rust_decimal = { version = "1.25", optional = true }
 bigdecimal_rs = { version = "0.3", package = "bigdecimal", optional = true }
 sea-orm = { version = "0.8", optional = true }
 zerocopy = { version = "0.6", optional = true }
+prost-types = { version = "0.11", optional = true }
+prost= { version = "0.11", optional = true }
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["clock"], default-features = false }
@@ -38,6 +40,7 @@ rand_chacha = "0.3"
 # Provide derive(Dummy) macros.
 derive = ["dummy"]
 bigdecimal = ["bigdecimal_rs", "rust_decimal"]
+prost = ["dep:prost-types", "dep:prost"]
 
 [[example]]
 name = "basic"

--- a/fake/src/faker/impls/administrative.rs
+++ b/fake/src/faker/impls/administrative.rs
@@ -26,15 +26,9 @@ impl Dummy<HealthInsuranceCode<FR_FR>> for String {
         let town_code: u16 = (0..999).fake_with_rng::<u16, _>(rng);
         let order_code: u16 = (0..999).fake_with_rng::<u16, _>(rng);
         let department_code: u16 = match department {
-            "2A" => {
-                19
-            }
-            "2B" => {
-                18
-            }
-            _ => {
-                department.parse::<u16>().unwrap()
-            }
+            "2A" => 19,
+            "2B" => 18,
+            _ => department.parse::<u16>().unwrap(),
         };
         let number = format!(
             "{}{:02}{:02}{}{:03}{:03}",

--- a/fake/src/faker/impls/automotive.rs
+++ b/fake/src/faker/impls/automotive.rs
@@ -9,10 +9,13 @@ use std::char;
 As with the SIV system, The letters I and O were never used because they could be confused with other characters, like 1 and 0.
 ref https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_France
 
-The letter U where also not used because it could be confused with V letter. 
+The letter U where also not used because it could be confused with V letter.
 ref on french wikipedia article https://fr.wikipedia.org/wiki/Plaque_d%27immatriculation_fran%C3%A7aise
 */
-const LICENSE_CHARS: [char; 23] = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W', 'X', 'Y', 'Z'];
+const LICENSE_CHARS: [char; 23] = [
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V',
+    'W', 'X', 'Y', 'Z',
+];
 
 #[inline]
 fn numerify_licence_plate<R: Rng + ?Sized>(string: &str, rng: &mut R) -> String {

--- a/fake/src/faker/impls/filesystem.rs
+++ b/fake/src/faker/impls/filesystem.rs
@@ -1925,7 +1925,7 @@ const UNSTABLE_SEMVER: &[&str] = &["alpha", "beta", "rc"];
 
 impl<L: Data> Dummy<Semver<L>> for String {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Semver<L>, rng: &mut R) -> Self {
-        let patch = &mut(0..20).fake_with_rng::<u8, _>(rng).to_string();
+        let patch = &mut (0..20).fake_with_rng::<u8, _>(rng).to_string();
         let probability = 10;
         if Boolean(EN, probability).fake_with_rng(rng) {
             patch.push_str(&format!(
@@ -1945,7 +1945,7 @@ impl<L: Data> Dummy<Semver<L>> for String {
 
 impl<L: Data> Dummy<SemverStable<L>> for String {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &SemverStable<L>, rng: &mut R) -> Self {
-        let patch = &mut(0..20).fake_with_rng::<u8, _>(rng).to_string();
+        let patch = &mut (0..20).fake_with_rng::<u8, _>(rng).to_string();
         format!(
             "{}.{}.{}",
             &(0..9).fake_with_rng::<u8, _>(rng).to_string(),
@@ -1957,7 +1957,7 @@ impl<L: Data> Dummy<SemverStable<L>> for String {
 
 impl<L: Data> Dummy<SemverUnstable<L>> for String {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &SemverUnstable<L>, rng: &mut R) -> Self {
-        let patch = &mut(0..20).fake_with_rng::<u8, _>(rng).to_string();
+        let patch = &mut (0..20).fake_with_rng::<u8, _>(rng).to_string();
         patch.push_str(&format!(
             "-{}.{}",
             *UNSTABLE_SEMVER.choose(rng).unwrap(),

--- a/fake/src/impls/color/mod.rs
+++ b/fake/src/impls/color/mod.rs
@@ -1,7 +1,7 @@
 use crate::{Dummy, Fake, Faker};
 use rand::Rng;
 
-use random_color::{RandomColor, Luminosity};
+use random_color::{Luminosity, RandomColor};
 
 impl Dummy<Faker> for RandomColor {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
@@ -9,7 +9,7 @@ impl Dummy<Faker> for RandomColor {
             hue: None,
             luminosity: Some(Luminosity::Random),
             seed: Some((u64::MIN..u64::MAX).fake_with_rng::<u64, _>(rng)),
-            alpha: Some((0..10).fake_with_rng::<i8, _>(rng) as f32 / 10.)
+            alpha: Some((0..10).fake_with_rng::<i8, _>(rng) as f32 / 10.),
         }
     }
 }

--- a/fake/src/impls/decimal/mod.rs
+++ b/fake/src/impls/decimal/mod.rs
@@ -20,7 +20,7 @@ impl Dummy<Faker> for rust_decimal::Decimal {
 
 impl Dummy<Decimal> for rust_decimal::Decimal {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Decimal, rng: &mut R) -> Self {
-            Faker.fake_with_rng(rng)
+        Faker.fake_with_rng(rng)
     }
 }
 
@@ -50,6 +50,8 @@ impl Dummy<PositiveDecimal> for rust_decimal::Decimal {
 
 impl Dummy<NoDecimalPoints> for rust_decimal::Decimal {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &NoDecimalPoints, rng: &mut R) -> Self {
-        Faker.fake_with_rng::<rust_decimal::Decimal, R>(rng).round_dp(0)
+        Faker
+            .fake_with_rng::<rust_decimal::Decimal, R>(rng)
+            .round_dp(0)
     }
 }

--- a/fake/src/impls/mod.rs
+++ b/fake/src/impls/mod.rs
@@ -23,3 +23,5 @@ pub mod time;
 pub mod uuid;
 #[cfg(feature = "zerocopy")]
 pub mod zerocopy_byteorder;
+#[cfg(feature = "prost")]
+pub mod prost;

--- a/fake/src/impls/prost/mod.rs
+++ b/fake/src/impls/prost/mod.rs
@@ -1,0 +1,69 @@
+use crate::{Dummy, Fake, Faker};
+use prost::Message;
+use rand::Rng;
+
+impl Dummy<Faker> for prost_types::value::Kind {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let i: u8 = (0..5).fake_with_rng(rng);
+        match i {
+            0 => Self::NullValue(0),
+            1 => Self::NumberValue(Faker.fake_with_rng(rng)),
+            2 => Self::StringValue(Faker.fake_with_rng(rng)),
+            3 => Self::BoolValue(Faker.fake_with_rng(rng)),
+            4 => Self::StructValue(Faker.fake_with_rng(rng)),
+            5 => Self::ListValue(Faker.fake_with_rng(rng)),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Dummy<Faker> for prost_types::Value {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        Self {
+            kind: Faker.fake_with_rng(rng),
+        }
+    }
+}
+
+impl Dummy<Faker> for prost_types::ListValue {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        Self {
+            values: Faker.fake_with_rng(rng),
+        }
+    }
+}
+
+impl Dummy<Faker> for prost_types::Struct {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        Self {
+            fields: Faker.fake_with_rng(rng),
+        }
+    }
+}
+
+const MIN_NANOS: i32 = 0;
+const MAX_NANOS: i32 = 999_999_999;
+
+impl Dummy<Faker> for prost_types::Timestamp {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let nanos = (MIN_NANOS..MAX_NANOS).fake_with_rng(rng);
+        Self {
+            seconds: Faker.fake_with_rng(rng),
+            nanos,
+        }
+    }
+}
+
+impl Dummy<Faker> for prost_types::Any {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let struct_value: prost_types::Struct = Faker.fake_with_rng(rng);
+
+        let mut value = Vec::new();
+        struct_value.encode(&mut value).unwrap();
+
+        Self {
+            type_url: "type.googleapis.com/google.protobuf.Struct".into(),
+            value,
+        }
+    }
+}

--- a/fake/src/impls/semver/mod.rs
+++ b/fake/src/impls/semver/mod.rs
@@ -1,12 +1,10 @@
-use crate::{Dummy, Fake, Faker};
 use crate::faker::boolean::raw::Boolean;
-use crate::locales::{EN};
+use crate::locales::EN;
+use crate::{Dummy, Fake, Faker};
 use rand::seq::SliceRandom;
 use rand::Rng;
 
-const UNSTABLE_SEMVER: &'static [&'static str] = &[
-    "alpha", "beta", "rc"
-];
+const UNSTABLE_SEMVER: &'static [&'static str] = &["alpha", "beta", "rc"];
 
 impl Dummy<Faker> for semver::Version {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
@@ -16,7 +14,8 @@ impl Dummy<Faker> for semver::Version {
                 "{}.{}",
                 *UNSTABLE_SEMVER.choose(rng).unwrap(),
                 &(0..9).fake_with_rng::<u8, _>(rng).to_string()
-            )).unwrap()
+            ))
+            .unwrap()
         } else {
             semver::Prerelease::EMPTY
         };

--- a/fake/src/impls/zerocopy_byteorder/mod.rs
+++ b/fake/src/impls/zerocopy_byteorder/mod.rs
@@ -23,4 +23,3 @@ byteorder_faker_impl!(I32);
 byteorder_faker_impl!(I64);
 #[cfg(not(target_os = "emscripten"))]
 byteorder_faker_impl!(I128);
-

--- a/fake/tests/derive_macros.rs
+++ b/fake/tests/derive_macros.rs
@@ -306,3 +306,16 @@ mod field_options {
         }
     }
 }
+
+mod test_trait_scope {
+    #[test]
+    #[allow(dead_code)]
+    fn it_generates_without_fake_in_scope() {
+        mod outer {
+            #[derive(fake::Dummy)]
+            pub struct Outer {
+                pub message: String,
+            }
+        }
+    }
+}

--- a/fake/tests/derive_macros.rs
+++ b/fake/tests/derive_macros.rs
@@ -107,10 +107,7 @@ mod field_options {
         #[test]
         fn override_range() {
             #[derive(Dummy)]
-            struct Obj(
-                #[dummy(faker = "100..200")]
-                i32
-            );
+            struct Obj(#[dummy(faker = "100..200")] i32);
 
             let o: Obj = Faker.fake_with_rng(&mut rng());
 
@@ -125,9 +122,7 @@ mod field_options {
                 Two,
             }
             #[derive(Dummy)]
-            struct Obj(
-                MyEnum,
-            );
+            struct Obj(MyEnum);
 
             let o: Obj = Faker.fake_with_rng(&mut rng());
 
@@ -137,10 +132,7 @@ mod field_options {
         #[test]
         fn with_default() {
             #[derive(Dummy)]
-            struct Obj(
-                #[dummy(default)]
-                String,
-            );
+            struct Obj(#[dummy(default)] String);
 
             let o: Obj = Faker.fake_with_rng(&mut rng());
 
@@ -150,10 +142,7 @@ mod field_options {
         #[test]
         fn with_override_faker() {
             #[derive(Dummy)]
-            struct Obj(
-                #[dummy(faker = "fake::faker::name::en::Name()")]
-                String,
-            );
+            struct Obj(#[dummy(faker = "fake::faker::name::en::Name()")] String);
 
             let o: Obj = Faker.fake_with_rng(&mut rng());
 
@@ -163,10 +152,7 @@ mod field_options {
         #[test]
         fn with_override_fixed_i32() {
             #[derive(Dummy)]
-            struct Obj(
-                #[dummy(fixed = "42")]
-                i32,
-            );
+            struct Obj(#[dummy(fixed = "42")] i32);
 
             let o: Obj = Faker.fake_with_rng(&mut rng());
 


### PR DESCRIPTION
I am using this crate in code generated by `tonic_build` but run into an issue with `fake::Fake` not being in scope for the call to `fake_with_rng`. I am not able to add this import since the code is all generated. 

However, using fully qualified syntax allows the Fake trait to be pulled in scope without explicitly importing it:

```
quote! {
    <#faker as #fake>::fake_with_rng::<#field_ty, _>(&#faker, rng)
}
```

This PR includes clippy fixes in the proc macro code and I also ran cargo fmt on the crate. The only functional change is in commit [`0088b8b`](https://github.com/cksac/fake-rs/pull/107/commits/0088b8bebdac98568050c1ac0b8b92bd30b6af6f).