### PR TITLE
feat: remove 'static lifetime from NumberWithFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ NameWithTitle();
 
 ```rust
 Digit();
-NumberWithFormat(fmt: &'static str);
+NumberWithFormat<'a>(fmt: &'a str);
 ```
 
 ## Boolean

--- a/fake/README.md
+++ b/fake/README.md
@@ -135,7 +135,7 @@ NameWithTitle();
 
 ```rust
 Digit();
-NumberWithFormat(fmt: &'static str);
+NumberWithFormat<'a>(fmt: &'a str);
 ```
 
 ## Boolean

--- a/fake/examples/fakers.rs
+++ b/fake/examples/fakers.rs
@@ -1,3 +1,4 @@
+use fake::faker::address::en::StreetName;
 use fake::locales::{EN, FR_FR, ZH_CN, ZH_TW};
 use fake::Fake;
 
@@ -266,6 +267,11 @@ fn number_faker() {
     println!("{:?}", val);
 
     let val: String = NumberWithFormat(EN, "FLAT 0# ^#/F").fake();
+    println!("{:?}", val);
+
+    // non-'static string
+    let fmt = String::from("FLAT 0# ^#/F");
+    let val: String = NumberWithFormat(EN, &fmt).fake();
     println!("{:?}", val);
 }
 

--- a/fake/src/faker/impls/number.rs
+++ b/fake/src/faker/impls/number.rs
@@ -18,7 +18,7 @@ impl<L: Data> Dummy<Digit<L>> for &str {
     }
 }
 
-impl<L: Data> Dummy<NumberWithFormat<L>> for String {
+impl<L: Data> Dummy<NumberWithFormat<'_, L>> for String {
     fn dummy_with_rng<R: Rng + ?Sized>(c: &NumberWithFormat<L>, rng: &mut R) -> Self {
         numerify_sym(c.1, rng)
     }

--- a/fake/src/faker/mod.rs
+++ b/fake/src/faker/mod.rs
@@ -15,30 +15,30 @@ fn numerify_sym<R: Rng + ?Sized>(string: &str, rng: &mut R) -> String {
 }
 
 macro_rules! def_fakers {
-    (@m $locale_m:ident=>$locale_s:ident { $($name:ident($($arg:ident : $typ:ty),*);)+}) => {
+    (@m $locale_m:ident=>$locale_s:ident { $($name:ident$(< $($lts:lifetime),* >)?($($arg:ident : $typ:ty),*);)+}) => {
         pub mod $locale_m {
             use super::raw;
             use crate::locales::$locale_s;
         $(
             #[inline]
             #[allow(non_snake_case)]
-            pub fn $name($($arg:$typ),*) -> raw::$name<$locale_s> {
+            pub fn $name$(< $($lts),* >)?($($arg:$typ),*) -> raw::$name<$locale_s> {
                 raw::$name($locale_s, $($arg),*)
             }
         )+
         }
     };
-    ($($name:ident($($arg:ident : $typ:ty),*);)+) => {
+    ($($name:ident$(< $($lts:lifetime),* >)?($($arg:ident : $typ:ty),*);)+) => {
         pub mod raw {
         $(
-            pub struct $name<L>(pub L, $(pub $typ),*);
+            pub struct $name<$( $($lts),* , )?L>(pub L, $(pub $typ),*);
         )+
         }
 
-        def_fakers!(@m en=>EN {$($name($($arg:$typ),*);)+});
-        def_fakers!(@m fr_fr=>FR_FR {$($name($($arg:$typ),*);)+});
-        def_fakers!(@m zh_tw=>ZH_TW {$($name($($arg:$typ),*);)+});
-        def_fakers!(@m zh_cn=>ZH_CN {$($name($($arg:$typ),*);)+});
+        def_fakers!(@m en=>EN {$($name$(< $($lts),* >)?($($arg:$typ),*);)+});
+        def_fakers!(@m fr_fr=>FR_FR {$($name$(< $($lts),* >)?($($arg:$typ),*);)+});
+        def_fakers!(@m zh_tw=>ZH_TW {$($name$(< $($lts),* >)?($($arg:$typ),*);)+});
+        def_fakers!(@m zh_cn=>ZH_CN {$($name$(< $($lts),* >)?($($arg:$typ),*);)+});
     };
 }
 
@@ -200,7 +200,7 @@ pub mod name {
 pub mod number {
     def_fakers! {
         Digit();
-        NumberWithFormat(fmt: &'static str);
+        NumberWithFormat<'a>(fmt: &'a str);
     }
 }
 


### PR DESCRIPTION
Expand the def_fakers macro to optionally capture the lifetime of the function so that NumberWithFormat could take an argument with a shorter-than-'static lifetime.