### PR TITLE
style: clippy fixes and reformat

### DIFF
--- a/fake/examples/fakers.rs
+++ b/fake/examples/fakers.rs
@@ -1,4 +1,3 @@
-use fake::faker::address::en::StreetName;
 use fake::locales::{EN, FR_FR, ZH_CN, ZH_TW};
 use fake::Fake;
 
@@ -369,8 +368,8 @@ fn chrono_faker() {
 #[cfg(feature = "semver")]
 fn filesystem_faker() {
     use fake::faker::filesystem::raw::*;
-    use std::path::PathBuf;
     use fake::Faker;
+    use std::path::PathBuf;
 
     let val: String = FilePath(EN).fake();
     println!("{:?}", val);

--- a/fake/examples/primitives.rs
+++ b/fake/examples/primitives.rs
@@ -27,7 +27,7 @@ fn main() {
         1, 0, 0, 0, 23, 0, 0, 0, 200, 1, 0, 0, 210, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0,
     ];
-    let ref mut rng = StdRng::from_seed(seed);
+    let rng = &mut StdRng::from_seed(seed);
     println!("{:?}", Faker.fake_with_rng::<u8, _>(rng));
     println!("{:?}", (1..8).fake_with_rng::<u8, _>(rng));
     for _ in 0..5 {

--- a/fake/examples/usage.rs
+++ b/fake/examples/usage.rs
@@ -51,7 +51,7 @@ fn main() {
         1, 0, 0, 0, 23, 0, 0, 0, 200, 1, 0, 0, 210, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0,
     ];
-    let ref mut r = StdRng::from_seed(seed);
+    let r = &mut StdRng::from_seed(seed);
     for _ in 0..5 {
         let v: usize = Faker.fake_with_rng(r);
         println!("value from fixed seed {}", v);

--- a/fake/src/faker/impls/barcode.rs
+++ b/fake/src/faker/impls/barcode.rs
@@ -79,7 +79,7 @@ fn get_properties<L: Data, R: Rng + ?Sized>(_c: L, rng: &mut R) -> IsbnPropertie
     let reg_pub = numerify_sym(&"#".repeat(reg_pub_len), rng);
 
     let mut reg_len = 0;
-    let sufix_reg_pub = &reg_pub[..reg_pub_len as usize - 1];
+    let sufix_reg_pub = &reg_pub[..reg_pub_len - 1];
 
     for r in &rules[group] {
         if r.min <= sufix_reg_pub && sufix_reg_pub <= r.max {
@@ -91,7 +91,7 @@ fn get_properties<L: Data, R: Rng + ?Sized>(_c: L, rng: &mut R) -> IsbnPropertie
         ean,
         group,
         registrant: reg_pub[..reg_len as usize].to_string(),
-        publication: reg_pub[reg_len as usize..reg_pub_len as usize].to_string(),
+        publication: reg_pub[reg_len as usize..reg_pub_len].to_string(),
     }
 }
 

--- a/fake/src/faker/impls/internet.rs
+++ b/fake/src/faker/impls/internet.rs
@@ -1,13 +1,13 @@
 use crate::faker::internet::raw::*;
 use crate::faker::lorem::raw::Word;
 use crate::faker::name::raw::FirstName;
-use crate::locales::{Data, EN};
+use crate::locales::Data;
 use crate::{Dummy, Fake, Faker};
-use unidecode::unidecode;
 use rand::distributions::{Distribution, Uniform};
 use rand::seq::SliceRandom;
 use rand::Rng;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use unidecode::unidecode;
 
 impl<L: Data> Dummy<FreeEmailProvider<L>> for String {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &FreeEmailProvider<L>, rng: &mut R) -> Self {

--- a/fake/src/locales/fr_fr.rs
+++ b/fake/src/locales/fr_fr.rs
@@ -71,6 +71,15 @@ impl Data for FR_FR {
         "orange.fr",
     ];
 
-    const PHONE_NUMBER_FORMATS: &'static [&'static str] = &["01 ## ## ## ##", "02 ## ## ## ##", "03 ## ## ## ##", "04 ## ## ## ##", "05 ## ## ## ##", "08 ## ## ## ##", "09 ## ## ## ##"];
-    const PHONE_CELL_NUMBER_FORMATS: &'static [&'static str] = &["06 ## ## ## ##", "07 ## ## ## ##"];
+    const PHONE_NUMBER_FORMATS: &'static [&'static str] = &[
+        "01 ## ## ## ##",
+        "02 ## ## ## ##",
+        "03 ## ## ## ##",
+        "04 ## ## ## ##",
+        "05 ## ## ## ##",
+        "08 ## ## ## ##",
+        "09 ## ## ## ##",
+    ];
+    const PHONE_CELL_NUMBER_FORMATS: &'static [&'static str] =
+        &["06 ## ## ## ##", "07 ## ## ## ##"];
 }


### PR DESCRIPTION
- Fixes clippy lint https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast -  Added in: pre 1.29.0
- Removes unused imports
- Used current stable fmt

I ignored newish lints
- https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref -  Added in: 1.64.0 
- https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args - Added in 1.66.0
Happy to add those, or create a `clippy.toml` to block those until they are deemed ready to be used here.