### PR TITLE
Allow generating any random DateTime<Tz> where Tz: Timezone + Dummy

### DIFF
--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -19,7 +19,7 @@ rand = "0.8"
 random_color = { version="0.6", optional = true }
 unidecode = "0.3"
 chrono = { version = "0.4", features = ["std"], optional = true, default-features = false }
-chrono-tz = { version = "0.6", optional = true }
+chrono-tz = { version = "0.8", optional = true }
 http = { version = "0.2", optional = true }
 semver = { version = "1", optional = true }
 uuid = { version = "1.2", features = ["v1", "v3", "v4", "v5"], optional = true }

--- a/fake/src/impls/chrono/mod.rs
+++ b/fake/src/impls/chrono/mod.rs
@@ -20,9 +20,20 @@ impl Dummy<Faker> for Duration {
     }
 }
 
-impl Dummy<Faker> for DateTime<Utc> {
+impl Dummy<Faker> for Utc {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, _: &mut R) -> Self {
+        Utc
+    }
+}
+
+impl<Tz> Dummy<Faker> for DateTime<Tz>
+where
+    Tz: TimeZone + Dummy<Faker>,
+{
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-        Utc.timestamp_nanos(Faker.fake_with_rng(rng))
+        let utc: DateTime<Utc> = Utc.timestamp_nanos(Faker.fake_with_rng(rng));
+        let tz: Tz = Faker.fake_with_rng(rng);
+        utc.with_timezone(&tz)
     }
 }
 

--- a/fake/src/impls/chrono_tz/mod.rs
+++ b/fake/src/impls/chrono_tz/mod.rs
@@ -18,4 +18,11 @@ mod tests {
         let tz: Tz = Faker.fake();
         assert!(TZ_VARIANTS.contains(&tz));
     }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn dummy_tz_through_datetime() {
+        let datetime: chrono::DateTime<Tz> = Faker.fake();
+        assert!(TZ_VARIANTS.contains(&datetime.timezone()));
+    }
 }


### PR DESCRIPTION
This means that any additional timezones will be supported automatically just as long as `Dummy<Faker>` is implemented for them.

This also updates the `chrono-tz` dependency to the newest major version.