### PR TITLE
feat: Add geo support

### DIFF
--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -20,11 +20,13 @@ random_color = { version="0.6", optional = true }
 unidecode = "0.3"
 chrono = { version = "0.4", features = ["std"], optional = true, default-features = false }
 chrono-tz = { version = "0.8", optional = true }
+geo-types = { version = "0.7", optional = true }
 http = { version = "0.2", optional = true }
 semver = { version = "1", optional = true }
 serde_json = { version = "1.0", optional = true }
 uuid = { version = "1.2", features = ["v1", "v3", "v4", "v5"], optional = true }
 time = { version = "0.3", features = ["formatting"], optional = true }
+num-traits = { version = "0.2", optional = true }
 rust_decimal = { version = "1.25", optional = true }
 bigdecimal_rs = { version = "0.3", package = "bigdecimal", optional = true }
 sea-orm = { version = "0.8", optional = true }
@@ -40,6 +42,7 @@ rand_chacha = "0.3"
 # Provide derive(Dummy) macros.
 derive = ["dummy"]
 bigdecimal = ["bigdecimal_rs", "rust_decimal"]
+geo = ["geo-types", "num-traits"]
 
 [[example]]
 name = "basic"

--- a/fake/README.md
+++ b/fake/README.md
@@ -25,6 +25,10 @@ If you want the timezone features from `chrono-tz`:
 ```toml
 fake = { version = "2.5", features=['chrono-tz']}
 ```
+If you want `geo` faker features:
+```toml
+fake = { version = "2.5", features=['geo']}
+```
 If you want `http` faker features:
 ```toml
 fake = { version = "2.5", features=['http']}

--- a/fake/src/impls/geo/mod.rs
+++ b/fake/src/impls/geo/mod.rs
@@ -1,0 +1,202 @@
+use std::ops::Range;
+
+use geo_types::CoordNum;
+use num_traits::cast;
+use rand::Rng;
+
+use crate::{Dummy, Fake, Faker};
+
+impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Coord<T> {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        geo_types::Coord::<T> {
+            x: Faker.fake_with_rng(rng),
+            y: Faker.fake_with_rng(rng),
+        }
+    }
+}
+
+impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Line<T> {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        geo_types::Line::<T> {
+            start: Faker.fake_with_rng(rng),
+            end: Faker.fake_with_rng(rng),
+        }
+    }
+}
+
+impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::LineString<T> {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        geo_types::LineString::<T>::new(Faker.fake_with_rng(rng))
+    }
+}
+
+impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::MultiLineString<T> {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        geo_types::MultiLineString::<T>::new(Faker.fake_with_rng(rng))
+    }
+}
+
+impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Point<T> {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        geo_types::Point::<T>::new(Faker.fake_with_rng(rng), Faker.fake_with_rng(rng))
+    }
+}
+
+impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::MultiPoint<T> {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        geo_types::MultiPoint::<T>::new(Faker.fake_with_rng(rng))
+    }
+}
+
+impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Polygon<T> {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        // Polygon will auto-close these LineString.
+        geo_types::Polygon::<T>::new(Faker.fake_with_rng(rng), Faker.fake_with_rng(rng))
+    }
+}
+
+impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::MultiPolygon<T> {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        geo_types::MultiPolygon::<T>::new(Faker.fake_with_rng(rng))
+    }
+}
+
+impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Rect<T> {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        // Rect points can not overlap.
+        let nums: Vec<T> = crate::unique::<T, _>(rng, 4);
+        let coord_1 = geo_types::Coord::<T> {
+            x: nums[0],
+            y: nums[1],
+        };
+        let coord_2 = geo_types::Coord::<T> {
+            x: nums[2],
+            y: nums[3],
+        };
+        geo_types::Rect::new::<geo_types::Coord<T>>(coord_1, coord_2)
+    }
+}
+
+impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Triangle<T> {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        // Triangle cant be a straight line, so avoid two identical slopes.
+        // There is a bug in slope that requires a different implementation
+        // https://github.com/georust/geo/issues/1001
+        // Also this uses f64 to avoid similar slopes when T is an integer.
+        fn abs_slope<T>(a: geo_types::Coord<T>, b: geo_types::Coord<T>) -> f64
+        where
+            T: CoordNum,
+        {
+            let (min_x, max_x) = if a.x > b.x { (b.x, a.x) } else { (a.x, b.x) };
+            let (min_y, max_y) = if a.y > b.y { (b.y, a.y) } else { (a.y, b.y) };
+            let delta_x: f64 = cast(max_x - min_x).unwrap();
+            let delta_y: f64 = cast(max_y - min_y).unwrap();
+            delta_y / delta_x
+        }
+        let nums: Vec<T> = crate::unique::<T, _>(rng, 6);
+        let coord_1 = geo_types::Coord::<T> {
+            x: nums[0],
+            y: nums[1],
+        };
+        let coord_2 = geo_types::Coord::<T> {
+            x: nums[2],
+            y: nums[3],
+        };
+
+        let slope_1 = abs_slope(coord_1, coord_2);
+
+        let mut coord_3 = geo_types::Coord::<T> {
+            x: nums[4],
+            y: nums[5],
+        };
+        let slope_2 = abs_slope(coord_2, coord_3);
+
+        if slope_1 == slope_2 {
+            // As the points are unique, swapping them will
+            // always produce a different slope.
+            coord_3 = geo_types::Coord::<T> {
+                x: nums[5],
+                y: nums[4],
+            };
+        }
+        geo_types::Triangle::<T>::new(coord_1, coord_2, coord_3)
+    }
+}
+
+const GEOMETRY_UNION_MEMBERS_IGNORE_RECURSIVE: usize = 7;
+const GEOMETRY_UNION_MEMBERS: Range<usize> = 0..9;
+
+// The GeometryCollection cant include a Geometry which is a GeometryCollection
+// to avoid overflowing the stack.
+struct NonRecursiveGeometry<T: CoordNum = f64>(geo_types::Geometry<T>);
+
+impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for NonRecursiveGeometry<T> {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let union_index: usize = GEOMETRY_UNION_MEMBERS.fake_with_rng(rng);
+        match union_index {
+            0 => NonRecursiveGeometry(geo_types::geometry::Geometry::Point::<T>(
+                Faker.fake_with_rng(rng),
+            )),
+            1 => NonRecursiveGeometry(geo_types::geometry::Geometry::Line::<T>(
+                Faker.fake_with_rng(rng),
+            )),
+            2 => NonRecursiveGeometry(geo_types::geometry::Geometry::LineString::<T>(
+                Faker.fake_with_rng(rng),
+            )),
+            3 => NonRecursiveGeometry(geo_types::geometry::Geometry::Polygon::<T>(
+                Faker.fake_with_rng(rng),
+            )),
+            4 => NonRecursiveGeometry(geo_types::geometry::Geometry::MultiPoint::<T>(
+                Faker.fake_with_rng(rng),
+            )),
+            5 => NonRecursiveGeometry(geo_types::geometry::Geometry::MultiLineString::<T>(
+                Faker.fake_with_rng(rng),
+            )),
+            6 => NonRecursiveGeometry(geo_types::geometry::Geometry::MultiPolygon::<T>(
+                Faker.fake_with_rng(rng),
+            )),
+            // Replace GeometryCollection with a Point
+            GEOMETRY_UNION_MEMBERS_IGNORE_RECURSIVE => NonRecursiveGeometry(
+                geo_types::geometry::Geometry::Point::<T>(Faker.fake_with_rng(rng)),
+            ),
+            8 => NonRecursiveGeometry(geo_types::geometry::Geometry::Rect::<T>(
+                Faker.fake_with_rng(rng),
+            )),
+            9 => NonRecursiveGeometry(geo_types::geometry::Geometry::Triangle::<T>(
+                Faker.fake_with_rng(rng),
+            )),
+            _ => panic!(),
+        }
+    }
+}
+
+impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Geometry<T> {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let union_index: usize = GEOMETRY_UNION_MEMBERS.fake_with_rng(rng);
+        match union_index {
+            0 => geo_types::geometry::Geometry::Point::<T>(Faker.fake_with_rng(rng)),
+            1 => geo_types::geometry::Geometry::Line::<T>(Faker.fake_with_rng(rng)),
+            2 => geo_types::geometry::Geometry::LineString::<T>(Faker.fake_with_rng(rng)),
+            3 => geo_types::geometry::Geometry::Polygon::<T>(Faker.fake_with_rng(rng)),
+            4 => geo_types::geometry::Geometry::MultiPoint::<T>(Faker.fake_with_rng(rng)),
+            5 => geo_types::geometry::Geometry::MultiLineString::<T>(Faker.fake_with_rng(rng)),
+            6 => geo_types::geometry::Geometry::MultiPolygon::<T>(Faker.fake_with_rng(rng)),
+            7 => geo_types::geometry::Geometry::GeometryCollection::<T>(Faker.fake_with_rng(rng)),
+            8 => geo_types::geometry::Geometry::Rect::<T>(Faker.fake_with_rng(rng)),
+            9 => geo_types::geometry::Geometry::Triangle::<T>(Faker.fake_with_rng(rng)),
+            _ => panic!(),
+        }
+    }
+}
+
+impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::GeometryCollection<T> {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        geo_types::GeometryCollection::<T>::new_from(
+            Faker
+                .fake_with_rng::<Vec<NonRecursiveGeometry<T>>, _>(rng)
+                .iter()
+                .map(|x| (x.0.to_owned()))
+                .collect::<Vec<geo_types::Geometry<T>>>(),
+        )
+    }
+}

--- a/fake/src/impls/mod.rs
+++ b/fake/src/impls/mod.rs
@@ -10,6 +10,8 @@ pub mod chrono_tz;
 pub mod color;
 #[cfg(feature = "rust_decimal")]
 pub mod decimal;
+#[cfg(feature = "geo-types")]
+pub mod geo;
 #[cfg(feature = "http")]
 pub mod http;
 #[cfg(feature = "sea-orm")]

--- a/fake/src/lib.rs
+++ b/fake/src/lib.rs
@@ -198,11 +198,41 @@ pub trait Fake: Sized {
 }
 impl<T> Fake for T {}
 
+#[cfg(feature = "geo")]
+fn unique<U: Dummy<Faker> + PartialEq, R: Rng + ?Sized>(rng: &mut R, len: usize) -> Vec<U> {
+    let mut set = Vec::<U>::new();
+    unique_append(&mut set, rng, len);
+    set
+}
+
+#[cfg(feature = "geo")]
+fn unique_append<U: Dummy<Faker> + PartialEq, R: Rng + ?Sized>(
+    set: &mut Vec<U>,
+    rng: &mut R,
+    len: usize,
+) {
+    while set.len() != len {
+        let new_item: U = Faker.fake_with_rng(rng);
+        let mut found = false;
+        for item in &mut *set {
+            if *item == new_item {
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            set.push(new_item);
+        }
+    }
+}
 #[macro_use]
 mod impls;
 pub use impls::std::path::PathFaker;
 pub use impls::std::result::ResultFaker;
 pub use impls::std::string::StringFaker;
+
+#[cfg(feature = "geo")]
+pub use impls::geo;
 
 #[cfg(feature = "uuid")]
 pub use impls::uuid;

--- a/fake/tests/determinism.rs
+++ b/fake/tests/determinism.rs
@@ -272,6 +272,48 @@ use fake::faker::phone_number::raw::*;
 check_determinism! { l10d CellNumber; String, fake_cell_number_en, fake_cell_number_fr, fake_cell_number_cn, fake_cell_number_tw, fake_cell_number_jp }
 check_determinism! { l10d PhoneNumber; String, fake_phone_number_en, fake_phone_number_fr, fake_phone_number_cn, fake_phone_number_tw, fake_phone_number_jp }
 
+#[cfg(feature = "geo-types")]
+mod geo {
+    use fake::{Fake, Faker};
+    use rand::SeedableRng as _;
+
+    check_determinism! { one fake_geo_coord_f64, geo_types::Coord<f64>, Faker }
+    check_determinism! { one fake_geo_coord_u64, geo_types::Coord<u64>, Faker }
+
+    check_determinism! { one fake_geo_line_f64, geo_types::Line<f64>, Faker }
+    check_determinism! { one fake_geo_line_u64, geo_types::Line<u64>, Faker }
+
+    check_determinism! { one fake_geo_linestring_f64, geo_types::LineString<f64>, Faker }
+    check_determinism! { one fake_geo_linestring_u64, geo_types::LineString<u64>, Faker }
+
+    check_determinism! { one fake_geo_multilinestring_f64, geo_types::MultiLineString<f64>, Faker }
+    check_determinism! { one fake_geo_multilinestring_u64, geo_types::MultiLineString<u64>, Faker }
+
+    check_determinism! { one fake_geo_point_f64, geo_types::Point<f64>, Faker }
+    check_determinism! { one fake_geo_point_u64, geo_types::Point<u64>, Faker }
+
+    check_determinism! { one fake_geo_multipoint_f64, geo_types::MultiPoint<f64>, Faker }
+    check_determinism! { one fake_geo_multipoint_u64, geo_types::MultiPoint<u64>, Faker }
+
+    check_determinism! { one fake_geo_multipolygon_f64, geo_types::MultiPolygon<f64>, Faker }
+    check_determinism! { one fake_geo_multipolygon_u64, geo_types::MultiPolygon<u64>, Faker }
+
+    check_determinism! { one fake_geo_polygon_f64, geo_types::Polygon<f64>, Faker }
+    check_determinism! { one fake_geo_polygon_u64, geo_types::Polygon<u64>, Faker }
+
+    check_determinism! { one fake_geo_rect_f64, geo_types::Rect<f64>, Faker }
+    check_determinism! { one fake_geo_rect_u64, geo_types::Rect<u64>, Faker }
+
+    check_determinism! { one fake_geo_triangle_f64, geo_types::Triangle<f64>, Faker }
+    check_determinism! { one fake_geo_triangle_u64, geo_types::Triangle<u64>, Faker }
+
+    check_determinism! { one fake_geo_geometry_f64, geo_types::Geometry<f64>, Faker }
+    check_determinism! { one fake_geo_geometry_u64, geo_types::Geometry<u64>, Faker }
+
+    check_determinism! { one fake_geo_geometry_collection_f64, geo_types::GeometryCollection<f64>, Faker }
+    check_determinism! { one fake_geo_geometry_collection_u64, geo_types::GeometryCollection<u64>, Faker }
+}
+
 // Decimal
 #[cfg(feature = "rust_decimal")]
 mod decimal {


### PR DESCRIPTION

There are many types in the broader GeoRust package collection which may also be added, but not everyone needs those hence the distinction between features `geo_types` and `geo`.