### PR TITLE
(dummy_derive) Use external prelude `::fake` to prevent conflicts with local modules

### DIFF
--- a/dummy_derive/src/lib.rs
+++ b/dummy_derive/src/lib.rs
@@ -59,8 +59,8 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
         }) => match style {
             ast::Style::Unit => {
                 let impl_dummy = quote! {
-                    impl fake::Dummy<fake::Faker> for #receiver_name {
-                        fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &fake::Faker, rng: &mut R) -> Self {
+                    impl ::fake::Dummy<::fake::Faker> for #receiver_name {
+                        fn dummy_with_rng<R: ::rand::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
                             #receiver_name
                         }
                     }
@@ -71,8 +71,8 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
                 let tuple_fields: Vec<_> = fields.iter().map(expose_field).collect();
 
                 let impl_dummy = quote! {
-                    impl fake::Dummy<fake::Faker> for #receiver_name {
-                        fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &fake::Faker, rng: &mut R) -> Self {
+                    impl ::fake::Dummy<::fake::Faker> for #receiver_name {
+                        fn dummy_with_rng<R: ::rand::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
                             #receiver_name(#(#tuple_fields),*)
                         }
                     }
@@ -96,8 +96,8 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
                     .collect();
 
                 let impl_dummy = quote! {
-                    impl fake::Dummy<fake::Faker> for #receiver_name {
-                        fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &fake::Faker, rng: &mut R) -> Self {
+                    impl ::fake::Dummy<::fake::Faker> for #receiver_name {
+                        fn dummy_with_rng<R: ::rand::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
                             #(#let_statements)*
                             #receiver_name {
                                 #(#struct_fields),*
@@ -168,8 +168,8 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
                     .collect();
 
                 let impl_dummy = quote! {
-                    impl fake::Dummy<fake::Faker> for #receiver_name {
-                        fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &fake::Faker, rng: &mut R) -> Self {
+                    impl ::fake::Dummy<::fake::Faker> for #receiver_name {
+                        fn dummy_with_rng<R: ::rand::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
                             match rng.gen_range(0..#variant_count) {
                                 #(#match_statements)*
                                 _ => {
@@ -183,8 +183,8 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
                 impl_dummy
             } else {
                 let impl_dummy = quote! {
-                    impl fake::Dummy<fake::Faker> for #receiver_name {
-                        fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &fake::Faker, rng: &mut R) -> Self {
+                    impl ::fake::Dummy<::fake::Faker> for #receiver_name {
+                        fn dummy_with_rng<R: ::rand::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
                             panic!("can not create an empty enum")
                         }
                     }


### PR DESCRIPTION
Without these changes, using dummy_derive in a module that has a child module with the name `fake` or `rand` resulted in confusing compiler error messages.

By using the [extern prelude](https://doc.rust-lang.org/stable/reference/names/preludes.html#extern-prelude) we avoid this issue.