### PR TITLE
Prevent warning about deprecated chrono support

### DIFF
--- a/fake/src/impls/chrono/mod.rs
+++ b/fake/src/impls/chrono/mod.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::{Dummy, Fake, Faker};
 use chrono::{Date, DateTime, Duration, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use rand::Rng;

--- a/fake/src/impls/sea_orm/mod.rs
+++ b/fake/src/impls/sea_orm/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Dummy, Fake, Faker};
+use crate::{Dummy, Faker};
 use sea_orm::prelude::Uuid;
 
 impl Dummy<Faker> for Uuid {


### PR DESCRIPTION
Currently there are six warnings like the following emitted during compilation of the chrono features

```rust
warning: use of deprecated struct `chrono::Date`: Use `NaiveDate` or `DateTime<Tz>` instead
 --> fake/src/impls/chrono/mod.rs:2:14
  |
2 | use chrono::{Date, DateTime, Duration, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
  |              ^^^^
  |
  = note: `#[warn(deprecated)]` on by default
```
and one about about the seo_orm feature

```rust
warning: unused import: `Fake`
 --> fake/src/impls/sea_orm/mod.rs:1:20
  |
1 | use crate::{Dummy, Fake, Faker};
  |                    ^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```