### PR TITLE
Add partial support for glam

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ features:
     - serde_json
     - time
     - zerocopy    
+    - glam
 - always-true-rng: expose AlwaysTrueRng
 - maybe-non-empty-collections: allow to use AlwaysTrueRng to generate non-empty collections
 

--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -31,6 +31,7 @@ rust_decimal = { version = "1.29", optional = true }
 bigdecimal_rs = { version = "0.3", package = "bigdecimal", optional = true }
 zerocopy = { version = "0.6", optional = true }
 rand_core = { version = "0.6", optional = true }
+glam = {version = "0.24.1", optional = true }
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["clock"], default-features = false }

--- a/fake/README.md
+++ b/fake/README.md
@@ -27,7 +27,8 @@ features:
     - semver
     - serde_json
     - time
-    - zerocopy    
+    - zerocopy  
+    - glam
 - always-true-rng: expose AlwaysTrueRng
 - maybe-non-empty-collections: allow to use AlwaysTrueRng to generate non-empty collections
 

--- a/fake/src/impls/glam/mod.rs
+++ b/fake/src/impls/glam/mod.rs
@@ -1,0 +1,87 @@
+use glam::{Mat4, Vec2, Vec3, Vec4};
+use crate::{Dummy, Fake, Faker};
+
+impl Dummy<Faker> for Mat4 {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_f: &Faker, rng: &mut R) -> Self {
+        let col_1: Vec4 = Faker.fake_with_rng(rng);
+        let col_2: Vec4 = Faker.fake_with_rng(rng);
+        let col_3: Vec4 = Faker.fake_with_rng(rng);
+        let col_4: Vec4 = Faker.fake_with_rng(rng);
+        Mat4::from_cols(col_1, col_2, col_3, col_4)
+    }
+}
+
+impl Dummy<Faker> for Vec3 {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_f: &Faker, rng: &mut R) -> Self {
+        let x: f32 = Faker.fake_with_rng(rng);
+        let y: f32 = Faker.fake_with_rng(rng);
+        let z: f32 = Faker.fake_with_rng(rng);
+        Vec3::new(x, y, z)
+    }
+}
+
+impl Dummy<Faker> for Vec2 {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_f: &Faker, rng: &mut R) -> Self {
+        let x: f32 = Faker.fake_with_rng(rng);
+        let y: f32 = Faker.fake_with_rng(rng);
+        Vec2::new(x, y)
+    }
+}
+
+impl Dummy<Faker> for Vec4 {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_f: &Faker, rng: &mut R) -> Self {
+        let x: f32 = Faker.fake_with_rng(rng);
+        let y: f32 = Faker.fake_with_rng(rng);
+        let z: f32 = Faker.fake_with_rng(rng);
+        let w: f32 = Faker.fake_with_rng(rng);
+        Vec4::new(x, y, z, w)
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::{vec2, vec3, vec4};
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    const SEED: [u8; 32] = [
+        1, 0, 0, 0, 23, 0, 0, 0, 200, 1, 0, 0, 210, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        1, 3, 5, 0,
+    ];
+
+    #[test]
+    fn fake_vec2() {
+        let rng = &mut StdRng::from_seed(SEED);
+        let expected = vec2(rng.gen(), rng.gen());
+        let rng = &mut StdRng::from_seed(SEED);
+        let fake = Faker.fake_with_rng::<Vec2, _>(rng);
+        assert_eq!(expected, fake);
+    }
+
+    #[test]
+    fn fake_vec3() {
+        let rng = &mut StdRng::from_seed(SEED);
+        let expected = vec3(rng.gen(), rng.gen(), rng.gen());
+        let rng = &mut StdRng::from_seed(SEED);
+        let fake = Faker.fake_with_rng::<Vec3, _>(rng);
+        assert_eq!(expected, fake);
+    }
+
+    #[test]
+    fn fake_vec4() {
+        let rng = &mut StdRng::from_seed(SEED);
+        let expected = vec4(rng.gen(), rng.gen(), rng.gen(), rng.gen());
+        let rng = &mut StdRng::from_seed(SEED);
+        let fake = Faker.fake_with_rng::<Vec4, _>(rng);
+        assert_eq!(expected, fake);
+    }
+
+    #[test]
+    fn fake_mat4() {
+        let rng = &mut StdRng::from_seed(SEED);
+        let expected: Vec<f32> = (0..16).map(|_| rng.gen()).collect();
+        let rng = &mut StdRng::from_seed(SEED);
+        let fake = Faker.fake_with_rng::<Mat4, _>(rng);
+        assert_eq!(expected[0..16], fake.to_cols_array());
+    }
+}

--- a/fake/src/impls/mod.rs
+++ b/fake/src/impls/mod.rs
@@ -25,3 +25,5 @@ pub mod time;
 pub mod uuid;
 #[cfg(feature = "zerocopy")]
 pub mod zerocopy_byteorder;
+#[cfg(feature = "glam")]
+pub mod glam;


### PR DESCRIPTION
I like both [glam-rs](https://github.com/bitshifter/glam-rs) and fake-rs, but up until now they wouldn't work together.

For my own purposes I've added glam support for `Vec2`, `Vec3`, `Vec4` and `Mat4`. If there is interest I'd be happy to add some more types (which would be straightforward).

All values are currently completely random, which may not always be the best. 