### PR TITLE
Improves the docs on derive

### DIFF
--- a/fake/src/lib.rs
+++ b/fake/src/lib.rs
@@ -50,6 +50,12 @@
 //! let words: Vec<String> = Words(3..5).fake();
 //! println!("words {:?}", words);
 //!
+//! // Using a tuple config list to generate a vector with a length range and a specific faker for the element
+//! let name_vec: Vec<String> = (Name(EN), 3..5).fake();
+//!
+//! // Using a macro as an alternative method for the tuple config list
+//! let name_vec = fake::vec![String as Name(EN); 3..5];
+//!
 //! // using macro to generate nested collection
 //! let name_vec = fake::vec![String as Name(EN); 4, 3..5, 2];
 //! println!("random nested vec {:?}", name_vec);
@@ -65,7 +71,8 @@
 //!     println!("value from fixed seed {}", v);
 //! }
 //!
-//! // Use an always true RNG so that optional types are always `Some` values.
+//! // Use an always true RNG so that optional types are always `Some` values. (Requires
+//! // always-true-rng feature).
 //! use fake::utils::AlwaysTrueRng;
 //! let mut rng = AlwaysTrueRng::default();
 //! let result: Option<i64> = Faker.fake_with_rng(&mut rng);


### PR DESCRIPTION
So I've done a bit of work to improve the derive docs.

I do think another improvement may be to copy the style done in the tokio docs and for some simple examples show how the generated code looks. However, I think fake would benefit less from this compared to tokio (how a runtime is setup for an async application is important to more people). So it may just add unnecessary noise to the docs. I've refrained from doing that but if you think it's an improvement just let me know and I can add it easily :smile:  

Fixes https://github.com/cksac/fake-rs/issues/138 