### PR TITLE
feat: expose rng trait hidden

### DIFF
--- a/dummy_derive/src/lib.rs
+++ b/dummy_derive/src/lib.rs
@@ -62,7 +62,7 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
             ast::Style::Unit => {
                 let impl_dummy = quote! {
                     impl ::fake::Dummy<::fake::Faker> for #receiver_name {
-                        fn dummy_with_rng<R: ::rand::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
+                        fn dummy_with_rng<R: ::fake::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
                             #receiver_name
                         }
                     }
@@ -74,7 +74,7 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
 
                 let impl_dummy = quote! {
                     impl ::fake::Dummy<::fake::Faker> for #receiver_name {
-                        fn dummy_with_rng<R: ::rand::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
+                        fn dummy_with_rng<R: ::fake::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
                             #receiver_name(#(#tuple_fields),*)
                         }
                     }
@@ -99,7 +99,7 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
 
                 let impl_dummy = quote! {
                     impl ::fake::Dummy<::fake::Faker> for #receiver_name {
-                        fn dummy_with_rng<R: ::rand::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
+                        fn dummy_with_rng<R: ::fake::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
                             #(#let_statements)*
                             #receiver_name {
                                 #(#struct_fields),*
@@ -171,7 +171,7 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
 
                 let impl_dummy = quote! {
                     impl ::fake::Dummy<::fake::Faker> for #receiver_name {
-                        fn dummy_with_rng<R: ::rand::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
+                        fn dummy_with_rng<R: ::fake::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
                             match rng.gen_range(0..#variant_count) {
                                 #(#match_statements)*
                                 _ => {
@@ -186,7 +186,7 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
             } else {
                 let impl_dummy = quote! {
                     impl ::fake::Dummy<::fake::Faker> for #receiver_name {
-                        fn dummy_with_rng<R: ::rand::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
+                        fn dummy_with_rng<R: ::fake::Rng + ?Sized>(_: &::fake::Faker, rng: &mut R) -> Self {
                             panic!("can not create an empty enum")
                         }
                     }

--- a/fake/src/lib.rs
+++ b/fake/src/lib.rs
@@ -78,7 +78,8 @@
 //! let result: Option<i64> = Faker.fake_with_rng(&mut rng);
 //! println!("Always Some: {}", result.unwrap());
 //! ```
-use rand::Rng;
+#[doc(hidden)]
+pub use rand::Rng;
 
 /// Generate default fake value for given type using [`Fake`].
 ///
@@ -286,7 +287,7 @@ pub mod locales;
 
 /// Derive macro generating an impl of the trait [`Dummy`]. This works for both structs and enums.
 ///
-/// # Attributes 
+/// # Attributes
 ///
 /// For any fields in the type there are a number of keys that can be used to control the code generation.
 /// All of these go within the dummy attribute.


### PR DESCRIPTION
This change exposes the `rand::Rng` as a hidden re-export, allowing users to derive with `Dummy`
without having to add the `rand` crate to their dependencies.

Currently, simple uses like deriving the `Dummy` macro requires one to add the `rand` crate to their
dependency tree, for it to not even be used directly in the code.