### PR TITLE
Replace unmaintained dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
 
 [[package]]
+name = "deunicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "890d779e1bc371e4fa7727ef6d29a9346be20ddfe40cd8c744cd083ce0640b15"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +271,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "chrono-tz",
+ "deunicode",
  "dummy",
  "fake",
  "geo-types",
@@ -280,7 +287,6 @@ dependencies = [
  "semver",
  "serde_json",
  "time",
- "unidecode",
  "url-escape",
  "uuid",
  "zerocopy",
@@ -879,12 +885,6 @@ name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
-
-[[package]]
-name = "unidecode"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402bb19d8e03f1d1a7450e2bd613980869438e0666331be3e073089124aa1adc"
 
 [[package]]
 name = "url-escape"

--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 dummy = { version = "0.6", path = "../dummy_derive", optional = true }
 rand = "0.8"
 random_color = { version = "0.6", optional = true }
-unidecode = "0.3"
+deunicode = "1.4"
 chrono = { version = "0.4", features = [
     "std",
 ], default-features = false, optional = true }

--- a/fake/src/faker/impls/internet.rs
+++ b/fake/src/faker/impls/internet.rs
@@ -7,7 +7,7 @@ use rand::distributions::{Distribution, Uniform};
 use rand::seq::SliceRandom;
 use rand::Rng;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use unidecode::unidecode;
+use deunicode::AsciiChars;
 
 impl<L: Data> Dummy<FreeEmailProvider<L>> for String {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &FreeEmailProvider<L>, rng: &mut R) -> Self {
@@ -39,7 +39,7 @@ impl<L: Data + Copy> Dummy<FreeEmail<L>> for String {
     fn dummy_with_rng<R: Rng + ?Sized>(c: &FreeEmail<L>, rng: &mut R) -> Self {
         let username: String = Username(c.0).fake_with_rng(rng);
         let provider: String = FreeEmailProvider(c.0).fake_with_rng(rng);
-        format!("{}@{}", unidecode(&username), provider)
+        format!("{}@{}", username.ascii_chars(), provider)
     }
 }
 

--- a/fake/src/lib.rs
+++ b/fake/src/lib.rs
@@ -71,12 +71,14 @@
 //!     println!("value from fixed seed {}", v);
 //! }
 //!
+//! # #[cfg(feture = "always-true-rng")] {
 //! // Use an always true RNG so that optional types are always `Some` values. (Requires
 //! // always-true-rng feature).
 //! use fake::utils::AlwaysTrueRng;
 //! let mut rng = AlwaysTrueRng::default();
 //! let result: Option<i64> = Faker.fake_with_rng(&mut rng);
 //! println!("Always Some: {}", result.unwrap());
+//! # }
 //! ```
 #[doc(hidden)]
 pub use rand::Rng;

--- a/fake/tests/always-true.rs
+++ b/fake/tests/always-true.rs
@@ -108,6 +108,7 @@ mod always_true_tests {
         assert_ne!(result.len(), 0);
     }
 
+    #[cfg(feature = "maybe-non-empty-collections")]
     #[test]
     fn test_vec_never_empty() {
         // Arrange


### PR DESCRIPTION
`deunicode` works with `format!` without allocating a temporary string, and is 160KB smaller than the unmaintained `unidecode`.
