### PR TITLE
fix: re-export correct features

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Default:
 
 ```toml
 [dependencies]
-fake = { version = "2.9", features = ["derive"] }
+fake = { version = "2.9.2", features = ["derive"] }
 ```
 
 Available features:
@@ -59,7 +59,7 @@ fn main() {
     // type derived Dummy
     let f: Foo = Faker.fake();
     println!("{:?}", f);
-    
+
     let b: Bar<Foo> = Faker.fake();
     println!("{:?}", b);
 

--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fake"
-version = "2.9.1"
+version = "2.9.2"
 authors = ["cksac <cs.cksac@gmail.com>"]
 description = "An easy to use library for generating fake data like name, number, address, lorem, dates, etc."
 keywords = ["faker", "data", "generator", "random"]

--- a/fake/README.md
+++ b/fake/README.md
@@ -11,7 +11,7 @@ Default:
 
 ```toml
 [dependencies]
-fake = { version = "2.9", features = ["derive"] }
+fake = { version = "2.9.2", features = ["derive"] }
 ```
 
 Available features:

--- a/fake/src/impls/time/mod.rs
+++ b/fake/src/impls/time/mod.rs
@@ -58,9 +58,9 @@ impl Dummy<Faker> for PrimitiveDateTime {
 pub struct Precision<const N: usize>;
 
 trait AllowedPrecision {
-    const SCALE: i128;
+    const SCALE: u32;
 
-    fn to_scale(nanos: i128) -> i128 {
+    fn to_scale(nanos: u32) -> u32 {
         if nanos != 0 {
             nanos / Self::SCALE * Self::SCALE
         } else {
@@ -68,13 +68,15 @@ trait AllowedPrecision {
         }
     }
 }
+
 macro_rules! allow_precision {
     ($($precision:expr),*) => {
         $(impl AllowedPrecision for Precision<$precision> {
-            const SCALE: i128 = 10i128.pow(9 - $precision);
+            const SCALE: u32 = 10u32.pow(9 - $precision);
         })*
     };
 }
+
 allow_precision!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
 impl<const N: usize> Dummy<Precision<N>> for Time
@@ -82,12 +84,9 @@ where
     Precision<N>: AllowedPrecision,
 {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Precision<N>, rng: &mut R) -> Self {
-        let hour = (0..24).fake_with_rng(rng);
-        let min = (0..60).fake_with_rng(rng);
-        let sec = (0..60).fake_with_rng(rng);
-        let nanos: i128 = (0..1_000_000_000).fake_with_rng(rng);
-        let nanos = Precision::<N>::to_scale(nanos) as u32;
-        Time::from_hms_nano(hour, min, sec, nanos).expect("failed to create time")
+        let time: Time = Faker.fake_with_rng(rng);
+        time.replace_nanosecond(Precision::<N>::to_scale(time.nanosecond()))
+            .expect("failed to create time")
     }
 }
 
@@ -107,8 +106,8 @@ where
     Precision<N>: AllowedPrecision,
 {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Precision<N>, rng: &mut R) -> Self {
-        let nanos = (MIN_NANOS..MAX_NANOS).fake_with_rng(rng);
-        let nanos = Precision::<N>::to_scale(nanos);
-        OffsetDateTime::from_unix_timestamp_nanos(nanos).unwrap()
+        let time: OffsetDateTime = Faker.fake_with_rng(rng);
+        time.replace_nanosecond(Precision::<N>::to_scale(time.nanosecond()))
+            .expect("failed to create time")
     }
 }

--- a/fake/src/lib.rs
+++ b/fake/src/lib.rs
@@ -257,11 +257,17 @@ pub use impls::uuid;
 #[cfg(feature = "rust_decimal")]
 pub use impls::decimal;
 
-#[cfg(feature = "bigdecimal")]
+#[cfg(any(feature = "bigdecimal", feature = "bigdecimal-rs"))]
 pub use impls::bigdecimal;
 
 #[cfg(feature = "serde_json")]
 pub use impls::serde_json;
+
+#[cfg(feature = "time")]
+pub use impls::time;
+
+#[cfg(feature = "chrono")]
+pub use impls::chrono;
 
 /// Fake value generation for specific formats.
 ///


### PR DESCRIPTION
Re-exports time and chrono correctly. Also bumps to 2.9.2.