### PR TITLE
Update glam to 0.27.0

### DIFF
--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -35,7 +35,7 @@ rust_decimal = { version = "1.32", default-features = false, optional = true }
 bigdecimal-rs = { version = "0.4", package = "bigdecimal", default-features = false, optional = true }
 zerocopy = { version = "0.7", optional = true }
 rand_core = { version = "0.6", optional = true }
-glam = { version = "0.26.0", optional = true }
+glam = { version = "0.27.0", optional = true }
 url-escape = { version = "0.1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Glam just release 0.27.0, so let's stay up to date.

I guess I'm just a bit unlucky with timing, usually a couple releases per year, but `0.26.0` was released on the day of my last PR and this one a week later :man_shrugging: 

https://github.com/bitshifter/glam-rs/tags