### PR TITLE
feat: Add functionality for bson::oid::ObjectId

### DIFF
--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -37,6 +37,7 @@ zerocopy = { version = "0.7", optional = true }
 rand_core = { version = "0.6", optional = true }
 glam = { version = "0.27.0", optional = true }
 url-escape = { version = "0.1", optional = true }
+bson = { version = "2.10", optional = true }
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["clock"], default-features = false }
@@ -55,6 +56,7 @@ maybe-non-empty-collections = ['always-true-rng']
 bigdecimal = ["bigdecimal-rs", "rust_decimal"]
 geo = ["geo-types", "num-traits"]
 http = ["dep:http", "url-escape"]
+bson_oid = ["bson"]
 
 [[example]]
 name = "basic"

--- a/fake/src/impls/bson_oid/mod.rs
+++ b/fake/src/impls/bson_oid/mod.rs
@@ -5,7 +5,9 @@ use bson::oid::ObjectId;
 use crate::{Dummy, Faker};
 
 impl Dummy<Faker> for ObjectId {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, _rng: &mut R) -> Self {
-        ObjectId::new()
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let mut bytes = [0u8; 12];
+        rng.fill(&mut bytes);
+        ObjectId::from_bytes(bytes)
     }
 }

--- a/fake/src/impls/bson_oid/mod.rs
+++ b/fake/src/impls/bson_oid/mod.rs
@@ -1,0 +1,11 @@
+//! bson_objectid
+
+use bson::oid::ObjectId;
+
+use crate::{Dummy, Faker};
+
+impl Dummy<Faker> for ObjectId {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, _rng: &mut R) -> Self {
+        ObjectId::new()
+    }
+}

--- a/fake/src/impls/mod.rs
+++ b/fake/src/impls/mod.rs
@@ -2,6 +2,8 @@
 
 #[cfg(feature = "bigdecimal-rs")]
 pub mod bigdecimal;
+#[cfg(feature = "bson_oid")]
+pub mod bson_oid;
 #[cfg(feature = "chrono")]
 pub mod chrono;
 #[cfg(feature = "chrono-tz")]

--- a/fake/src/lib.rs
+++ b/fake/src/lib.rs
@@ -273,6 +273,9 @@ pub use impls::time;
 #[cfg(feature = "chrono")]
 pub use impls::chrono;
 
+#[cfg(feature = "bson_oid")]
+pub use impls::bson_oid;
+
 /// Fake value generation for specific formats.
 ///
 /// It is structured in a way such that the modules here describes the custom

--- a/fake/tests/determinism.rs
+++ b/fake/tests/determinism.rs
@@ -358,3 +358,13 @@ mod serde_json {
     use rand::SeedableRng as _;
     check_determinism! { one fake_serde_json, serde_json::Value, Faker }
 }
+
+// BSON ObjectId
+#[cfg(feature = "bson_oid")]
+mod bson_oid {
+    use bson::oid::ObjectId;
+    use fake::{Fake, Faker};
+    use rand::SeedableRng as _;
+
+    check_determinism! { one fake_bson_oid, ObjectId, Faker }
+}


### PR DESCRIPTION
Hey there,

New to open source PR's so please forgive any mistakes on my end.

On a project I'm currently working with we've been using FakeRS for testing. Our structs require ObjectId fields to operate due to MongoDB. 

ObjectId's aren't deterministic due to their nature, so I'm not quite sure how to write a test for this.

I figured the best option would be to post what's currently working for me on a local branch I've been using and see if you folks are at all interested in this functionality being added or not before going any further.