### PR TITLE
Disable unnecessary proptest default features

### DIFF
--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -42,7 +42,7 @@ bson = { version = "2.10", optional = true }
 [dev-dependencies]
 chrono = { version = "0.4", features = ["clock"], default-features = false }
 fake = { path = ".", features = ["derive"] }
-proptest = "1.0.0"
+proptest = { version = "1.0.0", features = ["std"], default-features = false }
 rand_chacha = "0.3"
 
 [features]


### PR DESCRIPTION
This removes four dependencies
https://github.com/proptest-rs/proptest/blob/63ef67c/proptest/Cargo.toml#L22
- rusty-fork
- tempfile
- bit-set
- bit-vec