### PR TITLE
Update glam to 0.28

### DIFF
--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -35,7 +35,7 @@ rust_decimal = { version = "1.32", default-features = false, optional = true }
 bigdecimal-rs = { version = "0.4", package = "bigdecimal", default-features = false, optional = true }
 zerocopy = { version = "0.7", optional = true }
 rand_core = { version = "0.6", optional = true }
-glam = { version = "0.27.0", optional = true }
+glam = { version = "0.28.0", optional = true }
 url-escape = { version = "0.1", optional = true }
 bson = { version = "2.10", optional = true }
 


### PR DESCRIPTION
`glam` has released a new version lately which doesn't generate proper fake data for the `Vec*` structs. This solves the issue. 