### PR TITLE
fix: chrono Date range `0..` to `1..`

### DIFF
--- a/fake/src/impls/chrono/mod.rs
+++ b/fake/src/impls/chrono/mod.rs
@@ -55,7 +55,7 @@ where
 
 impl Dummy<Faker> for Date<Utc> {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-        let year: i32 = (0..YEAR_MAG).fake_with_rng(rng);
+        let year: i32 = (1..YEAR_MAG).fake_with_rng(rng);
         let end = if is_leap(year) { 366 } else { 365 };
         let day_ord: u32 = (1..end).fake_with_rng(rng);
         Utc.yo(year, day_ord)
@@ -73,7 +73,7 @@ impl Dummy<Faker> for NaiveTime {
 
 impl Dummy<Faker> for NaiveDate {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-        let year: i32 = (0..YEAR_MAG).fake_with_rng(rng);
+        let year: i32 = (1..YEAR_MAG).fake_with_rng(rng);
         let end = if is_leap(year) { 366 } else { 365 };
         let day_ord: u32 = (1..end).fake_with_rng(rng);
         NaiveDate::from_yo(year, day_ord)


### PR DESCRIPTION
# Background

The year 0000 does not exist by definition, which occasionally causes errors in programs.

## By ChatGPT

The year "0000" is generally considered invalid.
1.  Gregorian and Julian Calendars : These calendars start from year 1. There is no year 0; thus, "0000" is invalid.
2.  ISO 8601 : This international standard allows "0000" to represent the year before 1 AD (i.e., 1 BC). However, this usage is specialized and not common in everyday contexts.
3.  Programming and Databases : Some systems and databases may permit "0000", but this is due to specific technical requirements and is not standard practice.
4.  Historical and Archaeological Contexts : In these fields, the convention is that there is no year 0. The year before 1 AD is 1 BC.
Overall, in most standard and everyday contexts, "0000" is not a valid year.