### PR TITLE
Fix version in crate readme

### DIFF
--- a/fake/README.md
+++ b/fake/README.md
@@ -11,7 +11,7 @@ Default:
 
 ```toml
 [dependencies]
-fake = { version = "2.11.0", features = ["derive"] }
+fake = { version = "3.0.0", features = ["derive"] }
 ```
 
 Available features:


### PR DESCRIPTION
Seems like a decision was made to go for a major bump instead and this location was missed.