### PR TITLE
feat: add Precision::<N> support for chrono::NaiveDateTime

### DIFF
--- a/fake/src/impls/chrono/mod.rs
+++ b/fake/src/impls/chrono/mod.rs
@@ -124,6 +124,17 @@ where
     }
 }
 
+impl<const N: usize> Dummy<Precision<N>> for NaiveDateTime
+where
+    Precision<N>: AllowedPrecision,
+{
+    fn dummy_with_rng<R: Rng + ?Sized>(precision: &Precision<N>, rng: &mut R) -> Self {
+        let date = Faker.fake_with_rng(rng);
+        let time = Precision::<N>::fake_with_rng(precision, rng);
+        NaiveDateTime::new(date, time)
+    }
+}
+
 impl<Tz, const N: usize> Dummy<Precision<N>> for DateTime<Tz>
 where
     Tz: TimeZone + Dummy<Faker>,

--- a/fake/tests/determinism.rs
+++ b/fake/tests/determinism.rs
@@ -100,7 +100,7 @@ mod color {
 // Chrono
 #[cfg(feature = "chrono")]
 mod chrono {
-    use fake::{faker::chrono::raw::*, locales::*, Fake};
+    use fake::{chrono::Precision, faker::chrono::raw::*, locales::*, Fake};
     use rand::SeedableRng as _;
 
     fn lo() -> chrono::DateTime<chrono::Utc> {
@@ -121,6 +121,9 @@ mod chrono {
     check_determinism! { l10d DateTimeBetween; String, fake_date_time_between_en, fake_date_time_between_fr, fake_date_time_between_cn, fake_date_time_between_tw, fake_date_time_between_jp, fake_date_time_between_br, lo(), hi() }
     check_determinism! { l10d Duration; ::chrono::Duration, fake_duration_en, fake_duration_fr, fake_duration_cn, fake_duration_tw, fake_duration_jp, fake_duration_br }
     check_determinism! { l10d Time; String, fake_time_en, fake_time_fr, fake_time_cn, fake_time_tw, fake_time_jp, fake_time_br }
+    check_determinism! { one fake_naive_time_precision, ::chrono::NaiveTime, Precision::<6> }
+    check_determinism! { one fake_naive_date_time_precision, ::chrono::NaiveDateTime, Precision::<6> }
+    check_determinism! { one fake_date_time_precision, ::chrono::DateTime<::chrono::Utc>, Precision::<6> }
 }
 
 // time


### PR DESCRIPTION
This builds up on #146 by adding `Precision::<N>` support for `chrono::NaiveDateTime` and adding some tests for it.