### PR TITLE
feat: implement Dummy for `std::time::Duration`

### DIFF
--- a/fake/src/impls/std/mod.rs
+++ b/fake/src/impls/std/mod.rs
@@ -8,4 +8,5 @@ pub mod path;
 pub mod primitives;
 pub mod result;
 pub mod string;
+pub mod time;
 pub mod tuple;

--- a/fake/src/impls/std/time.rs
+++ b/fake/src/impls/std/time.rs
@@ -1,0 +1,11 @@
+use std::time::Duration;
+
+use crate::{Dummy, Fake, Faker};
+use rand::Rng;
+
+impl Dummy<Faker> for Duration {
+    #[inline]
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        Duration::from_nanos(Faker.fake_with_rng(rng))
+    }
+}


### PR DESCRIPTION
This PR implements `Dummy` for `std::time::Duration`.