### PR TITLE
feat: implement `Dummy` for `EmailAddress` newtype

### DIFF
--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -24,6 +24,7 @@ chrono = { version = "0.4", features = [
     "std",
 ], default-features = false, optional = true }
 chrono-tz = { version = "0.10", optional = true }
+email_address = { version = "0.2", optional = true }
 geo-types = { version = "0.7", default-features = false, optional = true }
 http = { version = "1", optional = true }
 semver = { version = "1", optional = true }

--- a/fake/src/impls/email_address/mod.rs
+++ b/fake/src/impls/email_address/mod.rs
@@ -1,0 +1,22 @@
+use std::str::FromStr;
+
+use email_address::EmailAddress;
+use rand::Rng;
+
+use crate::{
+    faker::internet::raw::{FreeEmail, SafeEmail},
+    locales::Data,
+    Dummy,
+};
+
+impl<L: Data + Copy> Dummy<FreeEmail<L>> for EmailAddress {
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &FreeEmail<L>, rng: &mut R) -> Self {
+        Self::from_str(&<String as Dummy<FreeEmail<L>>>::dummy_with_rng(c, rng)).unwrap()
+    }
+}
+
+impl<L: Data + Copy> Dummy<SafeEmail<L>> for EmailAddress {
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &SafeEmail<L>, rng: &mut R) -> Self {
+        Self::from_str(&<String as Dummy<SafeEmail<L>>>::dummy_with_rng(c, rng)).unwrap()
+    }
+}

--- a/fake/src/impls/mod.rs
+++ b/fake/src/impls/mod.rs
@@ -14,6 +14,8 @@ pub mod chrono_tz;
 pub mod color;
 #[cfg(feature = "rust_decimal")]
 pub mod decimal;
+#[cfg(feature = "email_address")]
+pub mod email_address;
 #[cfg(feature = "geo-types")]
 pub mod geo;
 #[cfg(feature = "glam")]


### PR DESCRIPTION
This PR implements `Dummy<FreeEmail<L>>` and `Dummy<SafeEmail<L>>` for the `EmailAddress` newtype from the [`email_address`](https://github.com/johnstonskj/rust-email_address) crate.