### PR TITLE
Update rand to 0.9.0 

### DIFF
--- a/dummy_derive/src/lib.rs
+++ b/dummy_derive/src/lib.rs
@@ -217,7 +217,7 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
                     impl #impl_generics #crate_name::Dummy<#crate_name::Faker> for #receiver_name #ty_generics #where_clause {
                         fn dummy_with_rng<R: #crate_name::Rng + ?Sized>(_: &#crate_name::Faker, rng: &mut R) -> Self {
                             let options = [#(#variant_opts),*];
-                            match #crate_name::rand::seq::SliceRandom::choose(
+                            match #crate_name::rand::seq::IndexedRandom::choose(
                                 <_ as ::std::convert::AsRef<[usize]>>::as_ref(&options),
                                 rng,
                             )

--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 dummy = { version = "0.9", path = "../dummy_derive", optional = true }
-rand = "0.8"
+rand = "0.9"
 random_color = { version = "1", optional = true }
 deunicode = "1.6"
 chrono = { version = "0.4", features = [
@@ -36,7 +36,7 @@ num-traits = { version = "0.2", optional = true }
 rust_decimal = { version = "1", default-features = false, optional = true }
 bigdecimal-rs = { version = "0.4", package = "bigdecimal", default-features = false, optional = true }
 zerocopy = { version = "0.8", optional = true }
-rand_core = { version = "0.6", optional = true }
+rand_core = { version = "0.9.0", optional = true }
 glam = { version = "0.29", optional = true }
 url-escape = { version = "0.1", optional = true }
 bson = { version = "2", optional = true }
@@ -49,7 +49,7 @@ base64 = { version = "0.22.1", optional = true }
 chrono = { version = "0.4", features = ["clock"], default-features = false }
 fake = { path = ".", features = ["derive"] }
 proptest = { version = "1.0.0", features = ["std"], default-features = false }
-rand_chacha = "0.3"
+rand_chacha = "0.9.0"
 
 [features]
 # Provide derive(Dummy) macros.

--- a/fake/examples/collections.rs
+++ b/fake/examples/collections.rs
@@ -1,5 +1,5 @@
 use fake::{Fake, Faker};
-use rand::distributions;
+use rand::distr;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 fn main() {
@@ -28,7 +28,7 @@ fn main() {
     println!("BTreeSet {:?}", btree_set);
 
     // generate fixed length nested vec [[[u8;2];3];4] with value using sampler
-    let sampler = distributions::Uniform::new_inclusive(1, 10);
+    let sampler = distr::Uniform::new_inclusive(1, 10).expect("Can sample uniform");
     let v3 = fake::vec![u8 as sampler; 4, 3, 2];
     println!("random nested vec {:?}", v3);
 

--- a/fake/examples/primitives.rs
+++ b/fake/examples/primitives.rs
@@ -1,5 +1,5 @@
 use fake::{Fake, Faker};
-use rand::distributions;
+use rand::distr;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
@@ -16,7 +16,7 @@ fn main() {
     println!("u8 ({}) in [MIN, MAX]", (..).fake::<u8>());
 
     // to reuse sampler `Uniform` for value generation
-    let sampler = distributions::Uniform::new_inclusive(1, 10);
+    let sampler = distr::Uniform::new_inclusive(1, 10).expect("Can");
     for _ in 0..5 {
         let v: usize = sampler.fake();
         println!("sample value {}", v);

--- a/fake/src/bin/cli/main.rs
+++ b/fake/src/bin/cli/main.rs
@@ -13,7 +13,7 @@ pub fn main() {
     let stdout = io::stdout();
     let mut buf_stdout = io::BufWriter::new(stdout);
 
-    let mut thread_rng = rand::thread_rng();
+    let mut thread_rng = rand::rng();
     let args = cli_parser();
 
     writeln!(

--- a/fake/src/faker/impls/address.rs
+++ b/fake/src/faker/impls/address.rs
@@ -3,7 +3,7 @@ use crate::faker::name::raw::{FirstName, LastName, Name};
 use crate::faker::numerify_sym;
 use crate::locales::Data;
 use crate::{Dummy, Fake, Faker};
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 
 impl<L: Data> Dummy<CityPrefix<L>> for String {

--- a/fake/src/faker/impls/administrative.rs
+++ b/fake/src/faker/impls/administrative.rs
@@ -1,7 +1,7 @@
 use crate::faker::administrative::raw::*;
 use crate::locales::FR_FR;
 use crate::{Dummy, Fake};
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 
 // ref https://fr.wikipedia.org/wiki/Num%C3%A9rotation_des_d%C3%A9partements_fran%C3%A7ais

--- a/fake/src/faker/impls/automotive.rs
+++ b/fake/src/faker/impls/automotive.rs
@@ -1,10 +1,9 @@
 use crate::faker::automotive::raw::*;
 use crate::locales::FR_FR;
 use crate::{Dummy, Fake};
-use rand::prelude::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 use std::char;
-
 /* ABC without I, O and U
 As with the SIV system, The letters I and O were never used because they could be confused with other characters, like 1 and 0.
 ref https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_France

--- a/fake/src/faker/impls/barcode.rs
+++ b/fake/src/faker/impls/barcode.rs
@@ -3,7 +3,7 @@ use crate::faker::boolean::raw::Boolean;
 use crate::faker::numerify_sym;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
-use rand::prelude::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 
 const ISBN_MAX_LENGTH: usize = 13;

--- a/fake/src/faker/impls/company.rs
+++ b/fake/src/faker/impls/company.rs
@@ -2,7 +2,7 @@ use crate::faker::company::raw::*;
 use crate::faker::name::raw::LastName;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 
 impl<L: Data> Dummy<CompanySuffix<L>> for String {

--- a/fake/src/faker/impls/creditcard.rs
+++ b/fake/src/faker/impls/creditcard.rs
@@ -1,7 +1,8 @@
 use crate::faker::creditcard::raw::CreditCardNumber;
 use crate::locales::Data;
 use crate::Dummy;
-use rand::{prelude::IteratorRandom, seq::SliceRandom, Rng};
+use rand::seq::{IndexedRandom, IteratorRandom};
+use rand::Rng;
 
 type PrefixCreditcard<'a> = (u8, Option<&'a [u8]>, &'a [usize]);
 

--- a/fake/src/faker/impls/currency.rs
+++ b/fake/src/faker/impls/currency.rs
@@ -1,7 +1,7 @@
 use crate::faker::currency::raw::*;
 use crate::locales::Data;
 use crate::Dummy;
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 
 impl<L: Data> Dummy<CurrencyCode<L>> for String {

--- a/fake/src/faker/impls/filesystem.rs
+++ b/fake/src/faker/impls/filesystem.rs
@@ -3,7 +3,7 @@ use crate::faker::filesystem::raw::*;
 use crate::impls::std::path::PathFaker;
 use crate::locales::{Data, EN};
 use crate::{Dummy, Fake};
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 use std::path::PathBuf;
 

--- a/fake/src/faker/impls/finance.rs
+++ b/fake/src/faker/impls/finance.rs
@@ -1,7 +1,7 @@
 use crate::faker::finance::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 
 const ALPHABET: &[char; 26] = &[
@@ -51,9 +51,9 @@ impl<L: Data> Dummy<Bic<L>> for String {
             );
         } else if prob < 90 {
             (
-                rng.gen_range('0'..='9'),
-                rng.gen_range('0'..='9'),
-                rng.gen_range('0'..='9'),
+                rng.random_range('0'..='9'),
+                rng.random_range('0'..='9'),
+                rng.random_range('0'..='9'),
             )
         } else {
             (

--- a/fake/src/faker/impls/internet.rs
+++ b/fake/src/faker/impls/internet.rs
@@ -4,8 +4,8 @@ use crate::faker::name::raw::FirstName;
 use crate::locales::Data;
 use crate::{Dummy, Fake, Faker};
 use deunicode::AsciiChars;
-use rand::distributions::{Distribution, Uniform};
-use rand::seq::SliceRandom;
+use rand::distr::{Distribution, Uniform};
+use rand::seq::IndexedRandom;
 use rand::Rng;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -86,7 +86,7 @@ impl<L: Data> Dummy<Password<L>> for String {
 
 impl<L: Data> Dummy<IPv4<L>> for String {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &IPv4<L>, rng: &mut R) -> Self {
-        let u = Uniform::new_inclusive(u8::MIN, u8::MAX);
+        let u = Uniform::new_inclusive(u8::MIN, u8::MAX).expect("u8::MIN <= u8::MAX");
         format!(
             "{}.{}.{}.{}",
             u.sample(rng),
@@ -106,7 +106,7 @@ impl<L: Data> Dummy<IPv4<L>> for Ipv4Addr {
 
 impl<L: Data> Dummy<IPv6<L>> for String {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &IPv6<L>, rng: &mut R) -> Self {
-        let u = Uniform::new_inclusive(u16::MIN, u16::MAX);
+        let u = Uniform::new_inclusive(u16::MIN, u16::MAX).expect("u16::MIN <= u16::MAX");
         format!(
             "{:X}:{:X}:{:X}:{:X}:{:X}:{:X}:{:X}:{:X}",
             u.sample(rng),
@@ -143,7 +143,7 @@ impl<L: Data> Dummy<IP<L>> for IpAddr {
 
 impl<L: Data> Dummy<MACAddress<L>> for String {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &MACAddress<L>, rng: &mut R) -> Self {
-        let u = Uniform::new_inclusive(u8::MIN, u8::MAX);
+        let u = Uniform::new_inclusive(u8::MIN, u8::MAX).expect("u8::MIN <= u8::MAX");
         format!(
             "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
             u.sample(rng),

--- a/fake/src/faker/impls/job.rs
+++ b/fake/src/faker/impls/job.rs
@@ -1,7 +1,7 @@
 use crate::faker::job::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 
 impl<L: Data> Dummy<Seniority<L>> for String {

--- a/fake/src/faker/impls/lorem.rs
+++ b/fake/src/faker/impls/lorem.rs
@@ -1,7 +1,7 @@
 use crate::faker::lorem::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 
 impl<L: Data> Dummy<Word<L>> for String {

--- a/fake/src/faker/impls/name.rs
+++ b/fake/src/faker/impls/name.rs
@@ -1,7 +1,7 @@
 use crate::faker::name::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 
 impl<L: Data> Dummy<FirstName<L>> for String {

--- a/fake/src/faker/impls/number.rs
+++ b/fake/src/faker/impls/number.rs
@@ -2,7 +2,7 @@ use crate::faker::number::raw::*;
 use crate::faker::numerify_sym;
 use crate::locales::Data;
 use crate::Dummy;
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 
 impl<L: Data> Dummy<Digit<L>> for String {

--- a/fake/src/faker/impls/phone_number.rs
+++ b/fake/src/faker/impls/phone_number.rs
@@ -2,7 +2,7 @@ use crate::faker::numerify_sym;
 use crate::faker::phone_number::raw::*;
 use crate::locales::Data;
 use crate::Dummy;
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 
 impl<L: Data> Dummy<PhoneNumber<L>> for String {

--- a/fake/src/impls/base64/mod.rs
+++ b/fake/src/impls/base64/mod.rs
@@ -38,14 +38,14 @@ impl Dummy<UrlSafeBase64> for String {
 }
 
 impl Dummy<Faker> for Base64Value {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_config: &Faker, rng: &mut R) -> Self {
         let s = String::dummy_with_rng(&Base64, rng);
         Base64Value(s)
     }
 }
 
 impl Dummy<Faker> for UrlSafeBase64Value {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_config: &Faker, rng: &mut R) -> Self {
         let s = String::dummy_with_rng(&UrlSafeBase64, rng);
         UrlSafeBase64Value(s)
     }

--- a/fake/src/impls/chrono/mod.rs
+++ b/fake/src/impls/chrono/mod.rs
@@ -32,7 +32,7 @@ impl Dummy<Faker> for Utc {
 
 impl Dummy<Faker> for FixedOffset {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-        if rng.gen_bool(0.5) {
+        if rng.random_bool(0.5) {
             let halves: i32 = (0..=28).fake_with_rng(rng);
             FixedOffset::east_opt(halves * 30 * 60).expect("failed to create FixedOffset")
         } else {

--- a/fake/src/impls/glam/mod.rs
+++ b/fake/src/impls/glam/mod.rs
@@ -61,7 +61,7 @@ mod tests {
     #[test]
     fn fake_vec2() {
         let rng = &mut StdRng::from_seed(SEED);
-        let expected = vec2(rng.gen(), rng.gen());
+        let expected = vec2(rng.random(), rng.random());
         let rng = &mut StdRng::from_seed(SEED);
         let fake = Faker.fake_with_rng::<Vec2, _>(rng);
         assert_eq!(expected, fake);
@@ -70,7 +70,7 @@ mod tests {
     #[test]
     fn fake_vec3() {
         let rng = &mut StdRng::from_seed(SEED);
-        let expected = vec3(rng.gen(), rng.gen(), rng.gen());
+        let expected = vec3(rng.random(), rng.random(), rng.random());
         let rng = &mut StdRng::from_seed(SEED);
         let fake = Faker.fake_with_rng::<Vec3, _>(rng);
         assert_eq!(expected, fake);
@@ -79,7 +79,7 @@ mod tests {
     #[test]
     fn fake_vec4() {
         let rng = &mut StdRng::from_seed(SEED);
-        let expected = vec4(rng.gen(), rng.gen(), rng.gen(), rng.gen());
+        let expected = vec4(rng.random(), rng.random(), rng.random(), rng.random());
         let rng = &mut StdRng::from_seed(SEED);
         let fake = Faker.fake_with_rng::<Vec4, _>(rng);
         assert_eq!(expected, fake);
@@ -88,7 +88,7 @@ mod tests {
     #[test]
     fn fake_mat4() {
         let rng = &mut StdRng::from_seed(SEED);
-        let expected: Vec<f32> = (0..16).map(|_| rng.gen()).collect();
+        let expected: Vec<f32> = (0..16).map(|_| rng.random()).collect();
         let rng = &mut StdRng::from_seed(SEED);
         let fake = Faker.fake_with_rng::<Mat4, _>(rng);
         assert_eq!(expected[0..16], fake.to_cols_array());

--- a/fake/src/impls/http/mod.rs
+++ b/fake/src/impls/http/mod.rs
@@ -1,6 +1,6 @@
 use crate::{Dummy, Fake, Faker};
 use http::uri;
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 use std::mem;
 use std::net::Ipv4Addr;
@@ -53,14 +53,14 @@ impl Dummy<Faker> for http::HeaderName {
 
 impl<T: Dummy<Faker>> Dummy<Faker> for http::HeaderMap<T> {
     fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
-        let len = rng.gen_range(1..10);
+        let len = rng.random_range(1..10);
         let mut map = http::HeaderMap::with_capacity(len);
         for _ in 0..len {
             let name: http::HeaderName = config.fake_with_rng(rng);
-            if rng.gen_bool(0.7) {
+            if rng.random_bool(0.7) {
                 map.insert(name, config.fake_with_rng(rng));
             } else {
-                for _ in 0..rng.gen_range(1..5) {
+                for _ in 0..rng.random_range(1..5) {
                     map.append(&name, config.fake_with_rng(rng));
                 }
             }
@@ -106,12 +106,12 @@ impl Dummy<Faker> for http::uri::Authority {
     fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let mut authority = String::new();
 
-        if rng.gen_bool(0.5) {
+        if rng.random_bool(0.5) {
             // Include password
             let user = config.fake_with_rng::<String, _>(rng);
             let username = url_escape::encode_userinfo(&user);
             authority.push_str(&username);
-            if rng.gen_bool(0.5) {
+            if rng.random_bool(0.5) {
                 authority.push(':');
                 let pass = config.fake_with_rng::<String, _>(rng);
                 let password = url_escape::encode_userinfo(&pass);
@@ -125,7 +125,7 @@ impl Dummy<Faker> for http::uri::Authority {
             0 => {
                 authority.push_str("localhost");
                 // Include port number
-                if rng.gen_bool(0.5) {
+                if rng.random_bool(0.5) {
                     let port_num = config.fake_with_rng::<u16, _>(rng);
                     authority.push(':');
                     authority.push_str(&port_num.to_string());
@@ -137,7 +137,7 @@ impl Dummy<Faker> for http::uri::Authority {
                 authority.push_str(&ip.to_string());
             }
             _ => {
-                if rng.gen_bool(0.5) {
+                if rng.random_bool(0.5) {
                     authority.push_str("www.");
                 }
                 let host_len = (1..100).fake_with_rng(rng);
@@ -145,7 +145,7 @@ impl Dummy<Faker> for http::uri::Authority {
                     .extend((0..host_len).map(|_| *VALID_SCHEME_CHARACTERS.choose(rng).unwrap()));
 
                 // Include port number
-                if rng.gen_bool(0.5) {
+                if rng.random_bool(0.5) {
                     let port_num = config.fake_with_rng::<u16, _>(rng);
                     authority.push(':');
                     authority.push_str(&port_num.to_string());
@@ -171,10 +171,10 @@ impl Dummy<Faker> for http::uri::Scheme {
                 // '.', '-'. Looking at a list of know schemes 28 seems to be the longest so I'll
                 // generate one a max of that long.
 
-                let len = rng.gen_range(1..29);
+                let len = rng.random_range(1..29);
                 let mut scheme = String::with_capacity(len);
-                scheme.push(rng.gen_range(b'a'..=b'z') as char);
-                if rng.gen_bool(0.5) {
+                scheme.push(rng.random_range(b'a'..=b'z') as char);
+                if rng.random_bool(0.5) {
                     scheme.make_ascii_uppercase();
                 }
                 scheme.extend((1..len).map(|_| *VALID_SCHEME_CHARACTERS.choose(rng).unwrap()));
@@ -193,7 +193,7 @@ impl Dummy<Faker> for http::uri::PathAndQuery {
             url_escape::encode_path(&config.fake_with_rng::<String, _>(rng))
         );
 
-        if rng.gen_bool(0.5) {
+        if rng.random_bool(0.5) {
             path.push('?');
             let mut query_parts = vec![];
             let query_len = (2..5).fake_with_rng(rng);

--- a/fake/src/impls/semver/mod.rs
+++ b/fake/src/impls/semver/mod.rs
@@ -1,7 +1,7 @@
 use crate::faker::boolean::raw::Boolean;
 use crate::locales::EN;
 use crate::{Dummy, Fake, Faker};
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 
 const UNSTABLE_SEMVER: &[&str] = &["alpha", "beta", "rc"];

--- a/fake/src/impls/std/net.rs
+++ b/fake/src/impls/std/net.rs
@@ -1,18 +1,18 @@
 use crate::{Dummy, Fake, Faker};
-use rand::distributions::{Distribution, Uniform};
+use rand::distr::{Distribution, Uniform};
 use rand::Rng;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
 impl Dummy<Faker> for Ipv4Addr {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-        let u = Uniform::new_inclusive(u8::MIN, u8::MAX);
+        let u = Uniform::new_inclusive(u8::MIN, u8::MAX).expect("u8::MIN <= u8::MAX");
         Ipv4Addr::new(u.sample(rng), u.sample(rng), u.sample(rng), u.sample(rng))
     }
 }
 
 impl Dummy<Faker> for Ipv6Addr {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-        let u = Uniform::new_inclusive(u16::MIN, u16::MAX);
+        let u = Uniform::new_inclusive(u16::MIN, u16::MAX).expect("u16::MIN <= u16::MAX");
         Ipv6Addr::new(
             u.sample(rng),
             u.sample(rng),

--- a/fake/src/impls/std/num.rs
+++ b/fake/src/impls/std/num.rs
@@ -1,20 +1,20 @@
 use crate::{Dummy, Faker};
-use rand::distributions::{Distribution, Uniform};
+use rand::distr::{Distribution, Uniform};
 use rand::Rng;
 use std::num::{
-    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
-    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
+    NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
 };
 
 macro_rules! signed_faker_impl {
     ($nz_typ: ty, $typ:ty) => {
         impl Dummy<Faker> for $nz_typ {
             fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-                if rng.gen_bool(0.5) {
-                    let u = Uniform::new_inclusive(<$typ>::MIN, -1);
+                if rng.random_bool(0.5) {
+                    let u = Uniform::new_inclusive(<$typ>::MIN, -1).expect("Can sample uniform");
                     <$nz_typ>::new(u.sample(rng)).unwrap()
                 } else {
-                    let u = Uniform::new_inclusive(1, <$typ>::MAX);
+                    let u = Uniform::new_inclusive(1, <$typ>::MAX).expect("Can sample uniform");
                     <$nz_typ>::new(u.sample(rng)).unwrap()
                 }
             }
@@ -26,7 +26,7 @@ macro_rules! unsigned_faker_impl {
     ($nz_typ: ty, $typ:ty) => {
         impl Dummy<Faker> for $nz_typ {
             fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-                let u = Uniform::new_inclusive(1, <$typ>::MAX);
+                let u = Uniform::new_inclusive(1, <$typ>::MAX).expect("Can sample uniform");
                 <$nz_typ>::new(u.sample(rng)).unwrap()
             }
         }
@@ -39,7 +39,6 @@ signed_faker_impl!(NonZeroI32, i32);
 signed_faker_impl!(NonZeroI64, i64);
 #[cfg(not(target_os = "emscripten"))]
 signed_faker_impl!(NonZeroI128, i128);
-signed_faker_impl!(NonZeroIsize, isize);
 
 unsigned_faker_impl!(NonZeroU8, u8);
 unsigned_faker_impl!(NonZeroU16, u16);

--- a/fake/src/impls/std/path.rs
+++ b/fake/src/impls/std/path.rs
@@ -1,6 +1,6 @@
 use crate::locales::{Data, EN};
 use crate::{Dummy, Fake, Faker};
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 use std::path::PathBuf;
 

--- a/fake/src/impls/std/primitives.rs
+++ b/fake/src/impls/std/primitives.rs
@@ -1,5 +1,5 @@
 use crate::{Dummy, Faker};
-use rand::distributions::{Distribution, Uniform};
+use rand::distr::{Distribution, Uniform};
 use rand::Rng;
 use std::ops;
 
@@ -17,30 +17,74 @@ macro_rules! faker_impl {
 
         impl Dummy<Faker> for $typ {
             fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-                rng.gen()
+                rng.random()
             }
         }
     };
+}
+
+impl Dummy<usize> for usize {
+    fn dummy(t: &usize) -> Self {
+        *t
+    }
+
+    fn dummy_with_rng<R: Rng + ?Sized>(t: &usize, _rng: &mut R) -> Self {
+        *t
+    }
+}
+
+impl Dummy<Faker> for usize {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        rng.random::<u64>() as usize
+    }
+}
+
+impl Dummy<isize> for isize {
+    fn dummy(t: &isize) -> Self {
+        *t
+    }
+
+    fn dummy_with_rng<R: Rng + ?Sized>(t: &isize, _rng: &mut R) -> Self {
+        *t
+    }
+}
+
+impl Dummy<Faker> for isize {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        rng.random::<i64>() as isize
+    }
+}
+
+impl Dummy<Uniform<u64>> for usize {
+    fn dummy_with_rng<R: Rng + ?Sized>(dist: &Uniform<u64>, rng: &mut R) -> Self {
+        dist.sample(rng) as usize
+    }
+}
+
+impl Dummy<Uniform<i64>> for isize {
+    fn dummy_with_rng<R: Rng + ?Sized>(dist: &Uniform<i64>, rng: &mut R) -> Self {
+        dist.sample(rng) as isize
+    }
 }
 
 macro_rules! range_impl {
     ($typ:ident) => {
         impl Dummy<ops::Range<Self>> for $typ {
             fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::Range<Self>, rng: &mut R) -> Self {
-                rng.gen_range(range.start..range.end)
+                rng.random_range(range.start..range.end)
             }
         }
 
         impl Dummy<ops::RangeFrom<Self>> for $typ {
             fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeFrom<Self>, rng: &mut R) -> Self {
-                let u = Uniform::new_inclusive(range.start, $typ::MAX);
+                let u = Uniform::new_inclusive(range.start, $typ::MAX).expect("Can sample uniform");
                 u.sample(rng)
             }
         }
 
         impl Dummy<ops::RangeFull> for $typ {
             fn dummy_with_rng<R: Rng + ?Sized>(_: &ops::RangeFull, rng: &mut R) -> Self {
-                let u = Uniform::new_inclusive($typ::MIN, $typ::MAX);
+                let u = Uniform::new_inclusive($typ::MIN, $typ::MAX).expect("Can sample uniform");
                 u.sample(rng)
             }
         }
@@ -50,14 +94,15 @@ macro_rules! range_impl {
                 range: &ops::RangeInclusive<Self>,
                 rng: &mut R,
             ) -> Self {
-                let u = Uniform::new_inclusive(range.start(), range.end());
+                let u =
+                    Uniform::new_inclusive(range.start(), range.end()).expect("Can sample uniform");
                 u.sample(rng)
             }
         }
 
         impl Dummy<ops::RangeTo<Self>> for $typ {
             fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeTo<Self>, rng: &mut R) -> Self {
-                rng.gen_range($typ::MIN..range.end)
+                rng.random_range($typ::MIN..range.end)
             }
         }
 
@@ -66,11 +111,93 @@ macro_rules! range_impl {
                 range: &ops::RangeToInclusive<Self>,
                 rng: &mut R,
             ) -> Self {
-                let u = Uniform::new_inclusive($typ::MIN, range.end);
+                let u = Uniform::new_inclusive($typ::MIN, range.end).expect("Can sample uniform");
                 u.sample(rng)
             }
         }
     };
+}
+
+impl Dummy<ops::Range<Self>> for usize {
+    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::Range<Self>, rng: &mut R) -> Self {
+        rng.random_range(range.start..range.end)
+    }
+}
+
+impl Dummy<ops::RangeFrom<Self>> for usize {
+    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeFrom<Self>, rng: &mut R) -> Self {
+        let u = Uniform::new_inclusive(range.start as u64, u64::MAX).expect("Can sample uniform");
+        u.sample(rng) as usize
+    }
+}
+
+impl Dummy<ops::RangeFull> for usize {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &ops::RangeFull, rng: &mut R) -> Self {
+        let u = Uniform::new_inclusive(u64::MIN, u64::MAX).expect("Can sample uniform");
+        u.sample(rng) as usize
+    }
+}
+
+impl Dummy<ops::RangeInclusive<Self>> for usize {
+    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeInclusive<Self>, rng: &mut R) -> Self {
+        let u = Uniform::new_inclusive(*range.start() as u64, *range.end() as u64)
+            .expect("Can sample uniform");
+        u.sample(rng) as usize
+    }
+}
+
+impl Dummy<ops::RangeTo<Self>> for usize {
+    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeTo<Self>, rng: &mut R) -> Self {
+        rng.random_range(u64::MIN..range.end as u64) as usize
+    }
+}
+
+impl Dummy<ops::RangeToInclusive<Self>> for usize {
+    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeToInclusive<Self>, rng: &mut R) -> Self {
+        let u = Uniform::new_inclusive(u64::MIN, range.end as u64).expect("Can sample uniform");
+        u.sample(rng) as usize
+    }
+}
+
+impl Dummy<ops::Range<Self>> for isize {
+    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::Range<Self>, rng: &mut R) -> Self {
+        rng.random_range(range.start as i64..range.end as i64) as isize
+    }
+}
+
+impl Dummy<ops::RangeFrom<Self>> for isize {
+    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeFrom<Self>, rng: &mut R) -> Self {
+        let u = Uniform::new_inclusive(range.start as i64, i64::MAX).expect("Can sample uniform");
+        u.sample(rng) as isize
+    }
+}
+
+impl Dummy<ops::RangeFull> for isize {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &ops::RangeFull, rng: &mut R) -> Self {
+        let u = Uniform::new_inclusive(i64::MIN, i64::MAX).expect("Can sample uniform");
+        u.sample(rng) as isize
+    }
+}
+
+impl Dummy<ops::RangeInclusive<Self>> for isize {
+    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeInclusive<Self>, rng: &mut R) -> Self {
+        let u = Uniform::new_inclusive(*range.start() as i64, *range.end() as i64)
+            .expect("Can sample uniform");
+        u.sample(rng) as isize
+    }
+}
+
+impl Dummy<ops::RangeTo<Self>> for isize {
+    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeTo<Self>, rng: &mut R) -> Self {
+        rng.random_range(i64::MIN..range.end as i64) as isize
+    }
+}
+
+impl Dummy<ops::RangeToInclusive<Self>> for isize {
+    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeToInclusive<Self>, rng: &mut R) -> Self {
+        let u = Uniform::new_inclusive(i64::MIN, range.end as i64).expect("Can sample uniform");
+        u.sample(rng) as isize
+    }
 }
 
 macro_rules! number_impl {
@@ -94,7 +221,6 @@ macro_rules! integer_impl {
 macro_rules! float_impl {
     ($typ:ident) => {
         faker_impl!($typ);
-        number_impl!($typ);
         range_impl!($typ);
     };
 }
@@ -109,7 +235,7 @@ integer_impl!(u32);
 integer_impl!(u64);
 #[cfg(not(target_os = "emscripten"))]
 integer_impl!(u128);
-integer_impl!(usize);
+//Manual explicit implementation for usize
 
 integer_impl!(i8);
 integer_impl!(i16);
@@ -117,7 +243,7 @@ integer_impl!(i32);
 integer_impl!(i64);
 #[cfg(not(target_os = "emscripten"))]
 integer_impl!(i128);
-integer_impl!(isize);
+//Manual explicit implementation for isize
 
 float_impl!(f32);
 float_impl!(f64);

--- a/fake/src/impls/std/string.rs
+++ b/fake/src/impls/std/string.rs
@@ -1,6 +1,6 @@
 use crate::{Dummy, Fake, Faker};
-use rand::distributions::Alphanumeric;
-use rand::seq::SliceRandom;
+use rand::distr::Alphanumeric;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 use std::ops;
 

--- a/fake/src/impls/ulid/mod.rs
+++ b/fake/src/impls/ulid/mod.rs
@@ -6,8 +6,8 @@ use crate::{Dummy, Faker};
 
 impl Dummy<Faker> for Ulid {
     fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-        let time_part: u64 = rng.gen_range(0..(1 << Ulid::TIME_BITS));
-        let rand_part: u128 = rng.gen_range(0..(1 << Ulid::RAND_BITS));
+        let time_part: u64 = rng.random_range(0..(1 << Ulid::TIME_BITS));
+        let rand_part: u128 = rng.random_range(0..(1 << Ulid::RAND_BITS));
         Ulid::from_parts(time_part, rand_part)
     }
 }

--- a/fake/src/impls/url/mod.rs
+++ b/fake/src/impls/url/mod.rs
@@ -1,5 +1,5 @@
-use crate::{Dummy, Fake, Faker};
-use rand::seq::SliceRandom;
+use crate::{Dummy, Faker};
+use rand::seq::IndexedRandom;
 use rand::Rng;
 use url::Url;
 

--- a/fake/src/impls/uuid/mod.rs
+++ b/fake/src/impls/uuid/mod.rs
@@ -45,7 +45,7 @@ pub struct UUIDv8;
 
 impl Dummy<UUIDv1> for Uuid {
     fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &UUIDv1, rng: &mut R) -> Self {
-        let ticks = rng.gen_range(uuid::timestamp::UUID_TICKS_BETWEEN_EPOCHS..u64::MAX);
+        let ticks = rng.random_range(uuid::timestamp::UUID_TICKS_BETWEEN_EPOCHS..u64::MAX);
         let counter = Faker.fake_with_rng(rng);
         let ts = uuid::timestamp::Timestamp::from_gregorian(ticks, counter);
         let node_id: [u8; 6] = Faker.fake_with_rng(rng);
@@ -61,7 +61,7 @@ impl Dummy<UUIDv1> for String {
 
 impl Dummy<UUIDv3> for Uuid {
     fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &UUIDv3, rng: &mut R) -> Self {
-        Builder::from_bytes(rng.gen())
+        Builder::from_bytes(rng.random())
             .with_variant(Variant::RFC4122)
             .with_version(Version::Md5)
             .into_uuid()
@@ -76,7 +76,7 @@ impl Dummy<UUIDv3> for String {
 
 impl Dummy<UUIDv4> for Uuid {
     fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &UUIDv4, rng: &mut R) -> Self {
-        Builder::from_bytes(rng.gen())
+        Builder::from_bytes(rng.random())
             .with_variant(Variant::RFC4122)
             .with_version(Version::Random)
             .into_uuid()
@@ -91,7 +91,7 @@ impl Dummy<UUIDv4> for String {
 
 impl Dummy<UUIDv5> for Uuid {
     fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &UUIDv5, rng: &mut R) -> Self {
-        Builder::from_bytes(rng.gen())
+        Builder::from_bytes(rng.random())
             .with_variant(Variant::RFC4122)
             .with_version(Version::Sha1)
             .into_uuid()
@@ -106,7 +106,7 @@ impl Dummy<UUIDv5> for String {
 
 impl Dummy<UUIDv6> for Uuid {
     fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &UUIDv6, rng: &mut R) -> Self {
-        let ticks = rng.gen_range(uuid::timestamp::UUID_TICKS_BETWEEN_EPOCHS..u64::MAX);
+        let ticks = rng.random_range(uuid::timestamp::UUID_TICKS_BETWEEN_EPOCHS..u64::MAX);
         let counter = Faker.fake_with_rng(rng);
         let ts = uuid::timestamp::Timestamp::from_gregorian(ticks, counter);
         let node_id: [u8; 6] = Faker.fake_with_rng(rng);
@@ -122,7 +122,7 @@ impl Dummy<UUIDv6> for String {
 
 impl Dummy<UUIDv7> for Uuid {
     fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &UUIDv7, rng: &mut R) -> Self {
-        let ticks = rng.gen_range(uuid::timestamp::UUID_TICKS_BETWEEN_EPOCHS..u64::MAX);
+        let ticks = rng.random_range(uuid::timestamp::UUID_TICKS_BETWEEN_EPOCHS..u64::MAX);
         let counter = Faker.fake_with_rng(rng);
         let ts = uuid::timestamp::Timestamp::from_gregorian(ticks, counter);
         Uuid::new_v7(ts)
@@ -150,6 +150,6 @@ impl Dummy<UUIDv8> for String {
 
 impl Dummy<Faker> for Uuid {
     fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-        Uuid::from_u128(rng.gen())
+        Uuid::from_u128(rng.random())
     }
 }

--- a/fake/src/lib.rs
+++ b/fake/src/lib.rs
@@ -133,7 +133,7 @@ pub struct Faker;
 /// ```
 /// use fake::{Dummy, Fake, Faker};
 /// use rand::Rng;
-/// use rand::seq::SliceRandom;
+/// use rand::seq::IndexedRandom;
 ///
 /// struct Name; // does not handle locale, see locales module for more
 ///
@@ -158,7 +158,7 @@ pub trait Dummy<T>: Sized {
     /// This can be left as a blanket implemented most of the time since it
     /// uses [`Dummy::dummy_with_rng`] under the hood.
     fn dummy(config: &T) -> Self {
-        let mut r = rand::thread_rng();
+        let mut r = rand::rng();
         Dummy::<T>::dummy_with_rng(config, &mut r)
     }
 
@@ -441,7 +441,7 @@ pub mod locales;
 ///
 /// impl Dummy<Faker> for Bar {
 ///     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-///         match rng.gen_range(0..3usize) {
+///         match rng.random_range(0..3usize) {
 ///             0 => Self::Simple,
 ///             1 => Self::Tuple(Fake::fake_with_rng::<i32, _>(&(0..5), rng)),
 ///             2 => {

--- a/fake/src/locales/de_de.rs
+++ b/fake/src/locales/de_de.rs
@@ -380,7 +380,7 @@ impl CityNameGenFn for DE_DE {
                     "{CitySuffix}",
                     CitySuffix(c.0).fake_with_rng::<&str, _>(rng),
                 )
-                .replace("{River}", RIVERS[rng.gen_range(0..RIVERS.len())]),
+                .replace("{River}", RIVERS[rng.random_range(0..RIVERS.len())]),
             _ => ADDRESS_CITY_WITHOUT_PREFIX
                 .replace(
                     "{CityName}",

--- a/fake/src/locales/pt_pt.rs
+++ b/fake/src/locales/pt_pt.rs
@@ -1,4 +1,4 @@
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 
 use crate::{
     faker::{automotive::raw::LicencePlate, impls::address::CityNameGenFn},

--- a/fake/src/utils.rs
+++ b/fake/src/utils.rs
@@ -44,7 +44,7 @@ pub fn either<A, B>(a: A, b: B) -> EitherFaker<A, B> {
 
 #[cfg(feature = "always-true-rng")]
 mod always_true_rng {
-    use rand::{rngs::mock::StepRng, Error, RngCore};
+    use rand::{rngs::mock::StepRng, RngCore};
     use rand_core::impls;
 
     #[derive(Clone, Debug, Eq, PartialEq)]
@@ -91,12 +91,6 @@ mod always_true_rng {
         #[inline]
         fn fill_bytes(&mut self, dest: &mut [u8]) {
             impls::fill_bytes_via_next(self, dest);
-        }
-
-        #[inline]
-        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-            self.fill_bytes(dest);
-            Ok(())
         }
     }
 }

--- a/fake/tests/always-true.rs
+++ b/fake/tests/always-true.rs
@@ -5,13 +5,13 @@ mod always_true_tests {
 
     #[test]
     fn test_rng_bool() {
-        use rand::{distributions::Standard, Rng};
-
+        use rand::distr::StandardUniform;
+        use rand::Rng;
         // Arrange
         let rng = AlwaysTrueRng::default();
 
         // Act
-        let result: std::vec::Vec<bool> = rng.sample_iter(Standard).take(6).collect();
+        let result: std::vec::Vec<bool> = rng.sample_iter(StandardUniform).take(6).collect();
 
         // Assert
         assert_eq!(&result, &[true, true, true, true, true, true]);
@@ -19,14 +19,14 @@ mod always_true_tests {
 
     #[test]
     fn test_rng_bool_wrap_large_increment() {
-        use rand::{distributions::Standard, Rng};
+        use rand::{distr::StandardUniform, Rng};
         let increment = 1 << 31;
 
         // Arrange
         let rng = AlwaysTrueRng::new(1, increment + 1);
 
         // Act
-        let iter = rng.sample_iter(Standard).take(10000);
+        let iter = rng.sample_iter(StandardUniform).take(10000);
 
         // Assert
         let mut i: u64 = 0;
@@ -38,13 +38,13 @@ mod always_true_tests {
 
     #[test]
     fn test_rng_int() {
-        use rand::{distributions::Standard, Rng};
+        use rand::{distr::StandardUniform, Rng};
 
         // Arrange
         let rng = AlwaysTrueRng::default();
 
         // Act
-        let result: std::vec::Vec<u64> = rng.sample_iter(Standard).take(6).collect();
+        let result: std::vec::Vec<u64> = rng.sample_iter(StandardUniform).take(6).collect();
 
         // Assert
         assert_eq!(
@@ -62,14 +62,14 @@ mod always_true_tests {
 
     #[test]
     fn test_rng_int_wrap() {
-        use rand::{distributions::Standard, Rng};
+        use rand::{distr::StandardUniform, Rng};
 
         // Arrange
         let increment = 1 << 31;
         let rng = AlwaysTrueRng::new((increment * 2) - 2, 1);
 
         // Act
-        let result: std::vec::Vec<u64> = rng.sample_iter(Standard).take(5).collect();
+        let result: std::vec::Vec<u64> = rng.sample_iter(StandardUniform).take(5).collect();
 
         // Assert
         assert_eq!(

--- a/fake/tests/derive_macros.rs
+++ b/fake/tests/derive_macros.rs
@@ -53,7 +53,7 @@ mod field_options {
 
             let o: MyEnum = Faker.fake_with_rng(&mut rng());
 
-            assert_eq!(o, MyEnum::Two(89, 0, 1));
+            assert_eq!(o, MyEnum::Two(56, 0, 1));
         }
 
         #[test]
@@ -73,7 +73,7 @@ mod field_options {
 
             let o: MyEnum = Faker.fake_with_rng(&mut rng());
 
-            assert_eq!(o, MyEnum::Two { x: 89, y: 0, z: 1 });
+            assert_eq!(o, MyEnum::Two { x: 56, y: 0, z: 1 });
         }
 
         #[test]
@@ -124,7 +124,7 @@ mod field_options {
 
             let o: Obj = Faker.fake_with_rng(&mut rng());
 
-            assert_eq!(o.0, 156);
+            assert_eq!(o.0, 167);
         }
 
         #[test]
@@ -198,7 +198,7 @@ mod field_options {
 
             let o: Obj = Faker.fake_with_rng(&mut rng());
 
-            assert_eq!(o.id, 156);
+            assert_eq!(o.id, 167);
         }
 
         #[test]


### PR DESCRIPTION
I wanted to create a PR to switch from rand 0.8.5 to 0.9.0. It is quite an involved upgrade and my knowledge of fake-rs is far from complete. I created a PR to get some feedback. I have one issue (and I'm not sure how many other issues this is hiding) with the proc-macro which won't compile anymore. I don't have much experience with proc macros, so I'm hoping the error below triggers something in somebody here.


For the actual upgrade notes see:

See: https://rust-random.github.io/book/update-0.9.html

The upgrade has quite a few breaking changes. Most notable are:
- Drop support for `usize` and `isize` from Uniform
- Uniform::sample returns result (used to panic)
- Deprecate `gen` like function names (replace with `random`)

The actual error I'm getting is this. To be honest, I'm not even sure where to begin to fix it. 

```
error[E0782]: expected a type, found a trait
  --> fake/tests/derive_macros.rs:22:22
   |
22 |             #[derive(Dummy, Debug, Eq, PartialEq)]
   |                      ^^^^^ in this derive macro expansion
   |
  ::: .../fake-rs/dummy_derive/src/lib.rs:59:1   |

```

