### PR TITLE
use fake Rnd re-export

### DIFF
--- a/fake/src/lib.rs
+++ b/fake/src/lib.rs
@@ -129,9 +129,8 @@ pub struct Faker;
 /// # Examples
 ///
 /// ```
-/// use fake::{Dummy, Fake, Faker};
-/// use rand::Rng;
-/// use rand::seq::IndexedRandom;
+/// use fake::rand::prelude::IndexedRandom;
+/// use fake::{Dummy, Fake, Faker, Rng};
 ///
 /// struct Name; // does not handle locale, see locales module for more
 ///
@@ -367,9 +366,8 @@ pub mod locales;
 /// This would generate code roughly equivalent to:
 ///
 /// ```
-/// use fake::{Dummy, Fake, Faker};
+/// use fake::{Dummy, Fake, Faker, Rng};
 /// use fake::faker::name::en::Name;
-/// use rand::Rng;
 ///
 /// pub struct Foo {
 ///     order_id: usize,
@@ -424,9 +422,8 @@ pub mod locales;
 /// This will generate code roughly equivalent to:
 ///
 /// ```
-/// use fake::{Dummy, Fake, Faker};
+/// use fake::{Dummy, Fake, Faker, Rng};
 /// use fake::faker::name::en::Name;
-/// use rand::Rng;
 ///
 /// pub enum Bar {
 ///     Simple,


### PR DESCRIPTION
By using the Fake re-export of Rng, we are sure that we're picking the right version of Rng, avoiding issues like https://github.com/cksac/fake-rs/issues/229.