### PR TITLE
Explain the format string in NumberWithFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,11 @@ NameWithTitle();
 
 ```rust
 Digit();
+
+// Format is a &str such that:
+// - `^` will be subsituted by a random number 1-9.
+// - `#` will be subsituted by a random number 0-9.
+// - Any other character will be left as-is.
 NumberWithFormat<'a>(fmt: &'a str);
 ```
 


### PR DESCRIPTION
Today I needed to generate number strings with fake-rs. I quickly found `NumberWithFormat`, but I had no clarity on how to use it and had to read the source code to figure out.

Does the explanation in the change reflect the behaviour correctly? Is this the correct way to document it? (I see no other examples in the README).