### PR TITLE
Adds markdown types to available options

### DIFF
--- a/fake/examples/fakers.rs
+++ b/fake/examples/fakers.rs
@@ -584,7 +584,7 @@ fn markdown_faker() {
     let val: String = BlockQuoteSingleLine(EN, 3..5).fake();
     println!("{:?}", val);
 
-    let val: String = BlockQuoteMultiLine(EN, 2..4).fake();
+    let val: Vec<String> = BlockQuoteMultiLine(EN, 2..4).fake();
     println!("{:?}", val);
 
     let val: String = Code(EN,1..5).fake();

--- a/fake/examples/fakers.rs
+++ b/fake/examples/fakers.rs
@@ -587,7 +587,7 @@ fn markdown_faker() {
     let val: Vec<String> = BlockQuoteMultiLine(EN, 2..4).fake();
     println!("{:?}", val);
 
-    let val: String = Code(EN,1..5).fake();
+    let val: String = Code(EN, 1..5).fake();
     println!("{:?}", val);
 }
 

--- a/fake/examples/fakers.rs
+++ b/fake/examples/fakers.rs
@@ -563,6 +563,34 @@ fn bigdecimal_faker() {
     println!("{:?}", val);
 }
 
+fn markdown_faker() {
+    use fake::faker::markdown::raw::*;
+
+    let val: String = ItalicWord(EN).fake();
+    println!("{:?}", val);
+
+    let val: String = BoldWord(EN).fake();
+    println!("{:?}", val);
+
+    let val: Vec<String> = BulletPoints(EN, 3..6).fake();
+    println!("{:?}", val);
+
+    let val: Vec<String> = ListItems(EN, 3..6).fake();
+    println!("{:?}", val);
+
+    let val: String = Link(EN).fake();
+    println!("{:?}", val);
+
+    let val: String = BlockQuoteSingleLine(EN, 3..5).fake();
+    println!("{:?}", val);
+
+    let val: String = BlockQuoteMultiLine(EN, 2..4).fake();
+    println!("{:?}", val);
+
+    let val: String = Code(EN,1..5).fake();
+    println!("{:?}", val);
+}
+
 fn main() {
     lorem_faker();
     name_faker();
@@ -578,6 +606,7 @@ fn main() {
     currency_faker();
     creditcard_faker();
     barcode_faker();
+    markdown_faker();
 
     #[cfg(feature = "random_color")]
     color_faker();

--- a/fake/src/bin/cli/fake_gen.rs
+++ b/fake/src/bin/cli/fake_gen.rs
@@ -201,6 +201,16 @@ pub fn all_fakegen_commands<R: Rng>() -> (
         (Paragraph(min:usize=5, max:usize=10),lorem),
         (Paragraphs(min:usize=5, max:usize=10)->Vec,lorem),
 
+        //markdown
+        (ItalicWord,markdown),
+        (BoldWord,markdown),
+        (Link,markdown),
+        (BulletPoints(min:usize=5, max:usize=10)->Vec,markdown),
+        (ListItems(min:usize=5, max:usize=10)->Vec,markdown),
+        (BlockQuoteSingleLine(min:usize=5, max:usize=10),markdown),
+        (BlockQuoteMultiLine(min:usize=5, max:usize=10)->Vec,markdown),
+        (Code(min:usize=5, max:usize=10),markdown),
+
         //name
         (FirstName,name),
         (LastName,name),

--- a/fake/src/faker/impls/markdown.rs
+++ b/fake/src/faker/impls/markdown.rs
@@ -1,78 +1,80 @@
-use crate::faker::markdown::raw::*;
 use crate::faker::lorem::raw::*;
+use crate::faker::markdown::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
 use rand::seq::IndexedRandom;
 use rand::Rng;
 
 impl<L: Data + Copy> Dummy<ItalicWord<L>> for String {
-  fn dummy_with_rng<R: Rng + ?Sized>(_: &ItalicWord<L>, rng: &mut R) -> Self {
-      let s = *L::LOREM_WORD.choose(rng).unwrap();
-      format!("*{}*", s)
-  }
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &ItalicWord<L>, rng: &mut R) -> Self {
+        let s = *L::LOREM_WORD.choose(rng).unwrap();
+        format!("*{}*", s)
+    }
 }
 
 impl<L: Data + Copy> Dummy<BoldWord<L>> for String {
-  fn dummy_with_rng<R: Rng + ?Sized>(_: &BoldWord<L>, rng: &mut R) -> Self {
-      let s = *L::LOREM_WORD.choose(rng).unwrap();
-      format!("**{}**", s)
-  }
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &BoldWord<L>, rng: &mut R) -> Self {
+        let s = *L::LOREM_WORD.choose(rng).unwrap();
+        format!("**{}**", s)
+    }
 }
 
 impl<L: Data + Copy> Dummy<Link<L>> for String {
-  fn dummy_with_rng<R: Rng + ?Sized>(c: &Link<L>, rng: &mut R) -> Self {
-      let text: String = Word(c.0).fake_with_rng::<&str, _>(rng).to_string();
-      let url: String = Word(c.0).fake_with_rng(rng);
-      format!("[{}](https://{})", text, url)
-  }
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &Link<L>, rng: &mut R) -> Self {
+        let text: String = Word(c.0).fake_with_rng::<&str, _>(rng).to_string();
+        let url: String = Word(c.0).fake_with_rng(rng);
+        format!("[{}](https://{})", text, url)
+    }
 }
 
 impl<L: Data + Copy> Dummy<BulletPoints<L>> for Vec<String> {
-  fn dummy_with_rng<R: Rng + ?Sized>(c: &BulletPoints<L>, rng: &mut R) -> Self {
-      let len: usize = c.1.fake_with_rng(rng);
-      let mut v: Vec<String> = Vec::with_capacity(len);
-      let w: Word<L> = Word(c.0);
-      for _ in 0..len {
-          v.push(format!("- {}", w.fake_with_rng::<&str, _>(rng)));
-      }
-      v
-  }
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &BulletPoints<L>, rng: &mut R) -> Self {
+        let len: usize = c.1.fake_with_rng(rng);
+        let mut v: Vec<String> = Vec::with_capacity(len);
+        let w: Word<L> = Word(c.0);
+        for _ in 0..len {
+            v.push(format!("- {}", w.fake_with_rng::<&str, _>(rng)));
+        }
+        v
+    }
 }
 
 impl<L: Data + Copy> Dummy<ListItems<L>> for Vec<String> {
-  fn dummy_with_rng<R: Rng + ?Sized>(c: &ListItems<L>, rng: &mut R) -> Self {
-      let len: usize = c.1.fake_with_rng(rng);
-      let mut v: Vec<String> = Vec::with_capacity(len);
-      let item: Word<L> = Word(c.0);
-      for i in 0..len {
-          v.push(format!("{}. {}", i + 1, item.fake_with_rng::<&str, _>(rng)));
-      }
-      v
-  }
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &ListItems<L>, rng: &mut R) -> Self {
+        let len: usize = c.1.fake_with_rng(rng);
+        let mut v: Vec<String> = Vec::with_capacity(len);
+        let item: Word<L> = Word(c.0);
+        for i in 0..len {
+            v.push(format!("{}. {}", i + 1, item.fake_with_rng::<&str, _>(rng)));
+        }
+        v
+    }
 }
 
 impl<L: Data + Copy> Dummy<BlockQuoteSingleLine<L>> for String {
-  fn dummy_with_rng<R: Rng + ?Sized>(c: &BlockQuoteSingleLine<L>, rng: &mut R) -> Self {
-      let sentence: String = Sentence(c.0, 4..10).fake_with_rng(rng);
-      format!("> {}", sentence)
-  }
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &BlockQuoteSingleLine<L>, rng: &mut R) -> Self {
+        let sentence: String = Sentence(c.0, 4..10).fake_with_rng(rng);
+        format!("> {}", sentence)
+    }
 }
 
 impl<L: Data + Copy> Dummy<BlockQuoteMultiLine<L>> for Vec<String> {
-  fn dummy_with_rng<R: Rng + ?Sized>(c: &BlockQuoteMultiLine<L>, rng: &mut R) -> Self {
-      let len: usize = c.1.fake_with_rng(rng);
-      let mut v: Vec<String> = Vec::with_capacity(len);
-      let sentence = Sentence(c.0, 4..10);
-      for _ in 0..len {
-          v.push(format!("> {}", sentence.fake_with_rng::<String, _>(rng)));
-      }
-      v
-  }
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &BlockQuoteMultiLine<L>, rng: &mut R) -> Self {
+        let len: usize = c.1.fake_with_rng(rng);
+        let mut v: Vec<String> = Vec::with_capacity(len);
+        let sentence = Sentence(c.0, 4..10);
+        for _ in 0..len {
+            v.push(format!("> {}", sentence.fake_with_rng::<String, _>(rng)));
+        }
+        v
+    }
 }
 
 impl<L: Data + Copy> Dummy<Code<L>> for String {
-  fn dummy_with_rng<R: Rng + ?Sized>(c: &Code<L>, rng: &mut R) -> Self {
-      let code: String = Sentence(c.0, 4..10).fake_with_rng::<String, _>(rng).to_string();
-      format!("```\n{}\n```", code)
-  }
+    fn dummy_with_rng<R: Rng + ?Sized>(c: &Code<L>, rng: &mut R) -> Self {
+        let code: String = Sentence(c.0, 4..10)
+            .fake_with_rng::<String, _>(rng)
+            .to_string();
+        format!("```\n{}\n```", code)
+    }
 }

--- a/fake/src/faker/impls/markdown.rs
+++ b/fake/src/faker/impls/markdown.rs
@@ -1,0 +1,78 @@
+use crate::faker::markdown::raw::*;
+use crate::faker::lorem::raw::*;
+use crate::locales::Data;
+use crate::{Dummy, Fake};
+use rand::seq::IndexedRandom;
+use rand::Rng;
+
+impl<L: Data + Copy> Dummy<ItalicWord<L>> for String {
+  fn dummy_with_rng<R: Rng + ?Sized>(_: &ItalicWord<L>, rng: &mut R) -> Self {
+      let s = *L::LOREM_WORD.choose(rng).unwrap();
+      format!("*{}*", s)
+  }
+}
+
+impl<L: Data + Copy> Dummy<BoldWord<L>> for String {
+  fn dummy_with_rng<R: Rng + ?Sized>(_: &BoldWord<L>, rng: &mut R) -> Self {
+      let s = *L::LOREM_WORD.choose(rng).unwrap();
+      format!("**{}**", s)
+  }
+}
+
+impl<L: Data + Copy> Dummy<Link<L>> for String {
+  fn dummy_with_rng<R: Rng + ?Sized>(c: &Link<L>, rng: &mut R) -> Self {
+      let text: String = Word(c.0).fake_with_rng::<&str, _>(rng).to_string();
+      let url: String = Word(c.0).fake_with_rng(rng);
+      format!("[{}](https://{})", text, url)
+  }
+}
+
+impl<L: Data + Copy> Dummy<BulletPoints<L>> for Vec<String> {
+  fn dummy_with_rng<R: Rng + ?Sized>(c: &BulletPoints<L>, rng: &mut R) -> Self {
+      let len: usize = c.1.fake_with_rng(rng);
+      let mut v: Vec<String> = Vec::with_capacity(len);
+      let w: Word<L> = Word(c.0);
+      for _ in 0..len {
+          v.push(format!("- {}", w.fake_with_rng::<&str, _>(rng)));
+      }
+      v
+  }
+}
+
+impl<L: Data + Copy> Dummy<ListItems<L>> for Vec<String> {
+  fn dummy_with_rng<R: Rng + ?Sized>(c: &ListItems<L>, rng: &mut R) -> Self {
+      let len: usize = c.1.fake_with_rng(rng);
+      let mut v: Vec<String> = Vec::with_capacity(len);
+      let item: Word<L> = Word(c.0);
+      for i in 0..len {
+          v.push(format!("{}. {}", i + 1, item.fake_with_rng::<&str, _>(rng)));
+      }
+      v
+  }
+}
+
+impl<L: Data + Copy> Dummy<BlockQuoteSingleLine<L>> for String {
+  fn dummy_with_rng<R: Rng + ?Sized>(c: &BlockQuoteSingleLine<L>, rng: &mut R) -> Self {
+      let sentence: String = Sentence(c.0, 4..10).fake_with_rng(rng);
+      format!("> {}", sentence)
+  }
+}
+
+impl<L: Data + Copy> Dummy<BlockQuoteMultiLine<L>> for Vec<String> {
+  fn dummy_with_rng<R: Rng + ?Sized>(c: &BlockQuoteMultiLine<L>, rng: &mut R) -> Self {
+      let len: usize = c.1.fake_with_rng(rng);
+      let mut v: Vec<String> = Vec::with_capacity(len);
+      let sentence = Sentence(c.0, 4..10);
+      for _ in 0..len {
+          v.push(format!("> {}", sentence.fake_with_rng::<String, _>(rng)));
+      }
+      v
+  }
+}
+
+impl<L: Data + Copy> Dummy<Code<L>> for String {
+  fn dummy_with_rng<R: Rng + ?Sized>(c: &Code<L>, rng: &mut R) -> Self {
+      let code: String = Sentence(c.0, 4..10).fake_with_rng::<String, _>(rng).to_string();
+      format!("```\n{}\n```", code)
+  }
+}

--- a/fake/src/faker/impls/mod.rs
+++ b/fake/src/faker/impls/mod.rs
@@ -17,9 +17,9 @@ pub mod http;
 pub mod internet;
 pub mod job;
 pub mod lorem;
+pub mod markdown;
 pub mod name;
 pub mod number;
 pub mod phone_number;
 #[cfg(feature = "time")]
 pub mod time;
-pub mod markdown;

--- a/fake/src/faker/impls/mod.rs
+++ b/fake/src/faker/impls/mod.rs
@@ -22,3 +22,4 @@ pub mod number;
 pub mod phone_number;
 #[cfg(feature = "time")]
 pub mod time;
+pub mod markdown;

--- a/fake/src/faker/mod.rs
+++ b/fake/src/faker/mod.rs
@@ -193,6 +193,19 @@ pub mod lorem {
     }
 }
 
+pub mod markdown {
+    def_fakers! {
+        ItalicWord();
+        BoldWord();
+        Link();
+        BulletPoints(count: std::ops::Range<usize>);
+        ListItems(count: std::ops::Range<usize>);
+        BlockQuoteSingleLine(count: std::ops::Range<usize>);
+        BlockQuoteMultiLine(count: std::ops::Range<usize>);
+        Code(count: std::ops::Range<usize>);
+    }
+}
+
 pub mod name {
     def_fakers! {
         FirstName();


### PR DESCRIPTION
Output of the example run:

```
"*non*"
"**eos**"
["- illum", "- et", "- et", "- veritatis"]
["1. nobis", "2. delectus", "3. doloribus", "4. suscipit", "5. dolores"]
"[et](https://ipsam)"
"> aut et pariatur adipisci quis in."
["> maxime nisi et sint iure quaerat aut et.", "> velit molestiae sint beatae excepturi adipisci.", "> vel odio eos molestiae."]
"```\nofficia neque ab debitis qui non reprehenderit ut nostrum.\n```"
```