### PR TITLE
Add support for `ferroid` ID types

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Available library features:
   - `chrono-tz`
   - `http`
   - `ulid`
+  - `ferroid`
   - `uuid`
   - `bigdecimal` (via `bigdecimal-rs`)
   - `rust_decimal`
@@ -461,6 +462,16 @@ DirPath();
 ```rust
 Bic();
 Isin();
+```
+
+### Ferroid
+
+```rust
+FerroidULID();
+FerroidTwitterId();
+FerroidInstagramId();
+FerroidMastodonId();
+FerroidDiscordId();
 ```
 
 ### UUID

--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -29,7 +29,8 @@ geo-types = { version = "0.7", default-features = false, optional = true }
 http = { version = "1", optional = true }
 semver = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
-ulid = { package = "ferroid", version = "0.5", optional = true, features = ["ulid"] }
+ulid = { version = "1", optional = true }
+ferroid = { version = "0.6", optional = true, features = ["std", "alloc", "snowflake", "ulid", "base32"] }
 uuid = { version = "1", features = [
     "v1",
     "v3",

--- a/fake/README.md
+++ b/fake/README.md
@@ -37,6 +37,7 @@ Available library features:
   - `chrono-tz`
   - `http`
   - `ulid`
+  - `ferroid`
   - `uuid`
   - `bigdecimal` (via `bigdecimal-rs`)
   - `rust_decimal`
@@ -452,6 +453,16 @@ DirPath();
 ```rust
 Bic();
 Isin();
+```
+
+### Ferroid
+
+```rust
+FerroidULID();
+FerroidTwitterId();
+FerroidInstagramId();
+FerroidMastodonId();
+FerroidDiscordId();
 ```
 
 ### UUID

--- a/fake/examples/derive.rs
+++ b/fake/examples/derive.rs
@@ -5,6 +5,7 @@ use fake::faker::boolean::en::*;
 use fake::faker::company::en::*;
 use fake::faker::lorem::en::*;
 use fake::faker::name::en::*;
+use fake::ferroid::*;
 use fake::utils::{either, WrappedVal};
 use fake::uuid::UUIDv4;
 use fake::Dummy;
@@ -125,6 +126,42 @@ struct FakerWrapperStruct {
     pub val: String,
 }
 
+#[derive(Debug, Dummy)]
+struct LogEntry {
+    #[dummy(faker = "FerroidULID")]
+    pub ulid: ferroid::ULID,
+
+    #[dummy(faker = "FerroidTwitterId")]
+    pub twitter_id: ferroid::SnowflakeTwitterId,
+
+    #[dummy(faker = "FerroidInstagramId")]
+    pub instagram_id: ferroid::SnowflakeInstagramId,
+
+    #[dummy(faker = "FerroidMastodonId")]
+    pub mastodon_id: ferroid::SnowflakeMastodonId,
+
+    #[dummy(faker = "FerroidDiscordId")]
+    pub discord_id: ferroid::SnowflakeDiscordId,
+}
+
+#[derive(Debug, Dummy)]
+struct LogEntryBase32 {
+    #[dummy(faker = "FerroidULID")]
+    pub ulid: String,
+
+    #[dummy(faker = "FerroidTwitterId")]
+    pub twitter_id: String,
+
+    #[dummy(faker = "FerroidInstagramId")]
+    pub instagram_id: String,
+
+    #[dummy(faker = "FerroidMastodonId")]
+    pub mastodon_id: String,
+
+    #[dummy(faker = "FerroidDiscordId")]
+    pub discord_id: String,
+}
+
 fn main() {
     let order: Order = Faker.fake();
     println!("{:#?}", order);
@@ -167,5 +204,11 @@ fn main() {
     println!("{:#?}", v);
 
     let v: FakerWrapperStruct = Faker.fake();
+    println!("{:#?}", v);
+
+    let v: LogEntry = Faker.fake();
+    println!("{:#?}", v);
+
+    let v: LogEntryBase32 = Faker.fake();
     println!("{:#?}", v);
 }

--- a/fake/examples/fakers.rs
+++ b/fake/examples/fakers.rs
@@ -507,6 +507,44 @@ fn barcode_faker() {
     println!("{}", val);
 }
 
+#[cfg(feature = "ferroid")]
+fn ferroid_faker() {
+    use fake::ferroid::*;
+    use ferroid::{
+        SnowflakeDiscordId, SnowflakeInstagramId, SnowflakeMastodonId, SnowflakeTwitterId, ULID,
+    };
+
+    let val: ULID = FerroidULID.fake();
+    println!("{:?}", val);
+
+    let val: String = FerroidULID.fake();
+    println!("{} (ULID)", val);
+
+    let val: SnowflakeTwitterId = FerroidTwitterId.fake();
+    println!("{:?}", val);
+
+    let val: String = FerroidTwitterId.fake();
+    println!("{} (SnowflakeTwitterId)", val);
+
+    let val: SnowflakeInstagramId = FerroidInstagramId.fake();
+    println!("{:?}", val);
+
+    let val: String = FerroidInstagramId.fake();
+    println!("{} (SnowflakeInstagramId)", val);
+
+    let val: SnowflakeDiscordId = FerroidDiscordId.fake();
+    println!("{:?}", val);
+
+    let val: String = FerroidDiscordId.fake();
+    println!("{} (SnowflakeDiscordId)", val);
+
+    let val: SnowflakeMastodonId = FerroidMastodonId.fake();
+    println!("{:?}", val);
+
+    let val: String = FerroidMastodonId.fake();
+    println!("{} (SnowflakeMastodonId)", val);
+}
+
 #[cfg(feature = "uuid")]
 fn uuid_faker() {
     use fake::uuid::*;
@@ -625,6 +663,9 @@ fn main() {
 
     #[cfg(feature = "chrono")]
     chrono_faker();
+
+    #[cfg(feature = "ferroid")]
+    ferroid_faker();
 
     #[cfg(feature = "uuid")]
     uuid_faker();

--- a/fake/src/impls/ferroid/mod.rs
+++ b/fake/src/impls/ferroid/mod.rs
@@ -1,0 +1,135 @@
+//! Fake _ferroid_ generation.
+
+use ferroid::{
+    Base32SnowExt, Base32UlidExt, SnowflakeDiscordId, SnowflakeInstagramId, SnowflakeMastodonId,
+    SnowflakeTwitterId, ULID,
+};
+
+use crate::{Dummy, Faker};
+
+pub struct FerroidULID;
+pub struct FerroidTwitterId;
+pub struct FerroidDiscordId;
+pub struct FerroidMastodonId;
+pub struct FerroidInstagramId;
+
+// --- ULID ---
+impl Dummy<Faker> for ULID {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let time_part: u128 = rng.random_range(0..(1 << ULID::TIMESTAMP_BITS));
+        let rand_part: u128 = rng.random_range(0..(1 << ULID::RANDOM_BITS));
+        ULID::from(time_part, rand_part)
+    }
+}
+impl Dummy<FerroidULID> for ULID {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &FerroidULID, rng: &mut R) -> Self {
+        let time_part: u128 = rng.random_range(0..(1 << ULID::TIMESTAMP_BITS));
+        let rand_part: u128 = rng.random_range(0..(1 << ULID::RANDOM_BITS));
+        ULID::from(time_part, rand_part)
+    }
+}
+impl Dummy<FerroidULID> for String {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &FerroidULID, rng: &mut R) -> Self {
+        ULID::dummy_with_rng(config, rng).encode().to_string()
+    }
+}
+
+// --- SnowflakeTwitterId ---
+impl Dummy<Faker> for SnowflakeTwitterId {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let timestamp: u64 = rng.random_range(0..(1 << SnowflakeTwitterId::TIMESTAMP_BITS));
+        let machine_id: u64 = rng.random_range(0..(1 << SnowflakeTwitterId::MACHINE_ID_BITS));
+        let sequence: u64 = rng.random_range(0..(1 << SnowflakeTwitterId::SEQUENCE_BITS));
+        SnowflakeTwitterId::from(timestamp, machine_id, sequence)
+    }
+}
+impl Dummy<FerroidTwitterId> for SnowflakeTwitterId {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &FerroidTwitterId, rng: &mut R) -> Self {
+        let timestamp: u64 = rng.random_range(0..(1 << SnowflakeTwitterId::TIMESTAMP_BITS));
+        let machine_id: u64 = rng.random_range(0..(1 << SnowflakeTwitterId::MACHINE_ID_BITS));
+        let sequence: u64 = rng.random_range(0..(1 << SnowflakeTwitterId::SEQUENCE_BITS));
+        SnowflakeTwitterId::from(timestamp, machine_id, sequence)
+    }
+}
+impl Dummy<FerroidTwitterId> for String {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &FerroidTwitterId, rng: &mut R) -> Self {
+        SnowflakeTwitterId::dummy_with_rng(config, rng)
+            .encode()
+            .to_string()
+    }
+}
+
+// --- SnowflakeDiscordId ---
+impl Dummy<Faker> for SnowflakeDiscordId {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let timestamp: u64 = rng.random_range(0..(1 << SnowflakeDiscordId::TIMESTAMP_BITS));
+        let machine_id: u64 = rng.random_range(0..(1 << SnowflakeDiscordId::MACHINE_ID_BITS));
+        let sequence: u64 = rng.random_range(0..(1 << SnowflakeDiscordId::SEQUENCE_BITS));
+        SnowflakeDiscordId::from(timestamp, machine_id, sequence)
+    }
+}
+impl Dummy<FerroidDiscordId> for SnowflakeDiscordId {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &FerroidDiscordId, rng: &mut R) -> Self {
+        let timestamp: u64 = rng.random_range(0..(1 << SnowflakeDiscordId::TIMESTAMP_BITS));
+        let machine_id: u64 = rng.random_range(0..(1 << SnowflakeDiscordId::MACHINE_ID_BITS));
+        let sequence: u64 = rng.random_range(0..(1 << SnowflakeDiscordId::SEQUENCE_BITS));
+        SnowflakeDiscordId::from(timestamp, machine_id, sequence)
+    }
+}
+impl Dummy<FerroidDiscordId> for String {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &FerroidDiscordId, rng: &mut R) -> Self {
+        SnowflakeDiscordId::dummy_with_rng(config, rng)
+            .encode()
+            .to_string()
+    }
+}
+
+// --- SnowflakeMastodonId ---
+impl Dummy<Faker> for SnowflakeMastodonId {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let timestamp: u64 = rng.random_range(0..(1 << SnowflakeMastodonId::TIMESTAMP_BITS));
+        let machine_id: u64 = rng.random_range(0..(1 << SnowflakeMastodonId::MACHINE_ID_BITS));
+        let sequence: u64 = rng.random_range(0..(1 << SnowflakeMastodonId::SEQUENCE_BITS));
+        SnowflakeMastodonId::from(timestamp, machine_id, sequence)
+    }
+}
+impl Dummy<FerroidMastodonId> for SnowflakeMastodonId {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &FerroidMastodonId, rng: &mut R) -> Self {
+        let timestamp: u64 = rng.random_range(0..(1 << SnowflakeMastodonId::TIMESTAMP_BITS));
+        let machine_id: u64 = rng.random_range(0..(1 << SnowflakeMastodonId::MACHINE_ID_BITS));
+        let sequence: u64 = rng.random_range(0..(1 << SnowflakeMastodonId::SEQUENCE_BITS));
+        SnowflakeMastodonId::from(timestamp, machine_id, sequence)
+    }
+}
+impl Dummy<FerroidMastodonId> for String {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &FerroidMastodonId, rng: &mut R) -> Self {
+        SnowflakeMastodonId::dummy_with_rng(config, rng)
+            .encode()
+            .to_string()
+    }
+}
+
+// --- SnowflakeInstagramId ---
+impl Dummy<Faker> for SnowflakeInstagramId {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let timestamp: u64 = rng.random_range(0..(1 << SnowflakeInstagramId::TIMESTAMP_BITS));
+        let machine_id: u64 = rng.random_range(0..(1 << SnowflakeInstagramId::MACHINE_ID_BITS));
+        let sequence: u64 = rng.random_range(0..(1 << SnowflakeInstagramId::SEQUENCE_BITS));
+        SnowflakeInstagramId::from(timestamp, machine_id, sequence)
+    }
+}
+impl Dummy<FerroidInstagramId> for SnowflakeInstagramId {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &FerroidInstagramId, rng: &mut R) -> Self {
+        let timestamp: u64 = rng.random_range(0..(1 << SnowflakeInstagramId::TIMESTAMP_BITS));
+        let machine_id: u64 = rng.random_range(0..(1 << SnowflakeInstagramId::MACHINE_ID_BITS));
+        let sequence: u64 = rng.random_range(0..(1 << SnowflakeInstagramId::SEQUENCE_BITS));
+        SnowflakeInstagramId::from(timestamp, machine_id, sequence)
+    }
+}
+impl Dummy<FerroidInstagramId> for String {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &FerroidInstagramId, rng: &mut R) -> Self {
+        SnowflakeInstagramId::dummy_with_rng(config, rng)
+            .encode()
+            .to_string()
+    }
+}

--- a/fake/src/impls/mod.rs
+++ b/fake/src/impls/mod.rs
@@ -16,6 +16,8 @@ pub mod color;
 pub mod decimal;
 #[cfg(feature = "email_address")]
 pub mod email_address;
+#[cfg(feature = "ferroid")]
+pub mod ferroid;
 #[cfg(feature = "geo-types")]
 pub mod geo;
 #[cfg(feature = "glam")]

--- a/fake/src/impls/ulid/mod.rs
+++ b/fake/src/impls/ulid/mod.rs
@@ -1,13 +1,13 @@
 //! Fake _ulid_ generation.
 
-use ulid::ULID;
+use ulid::Ulid;
 
 use crate::{Dummy, Faker};
 
-impl Dummy<Faker> for ULID {
+impl Dummy<Faker> for Ulid {
     fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-        let time_part: u128 = rng.random_range(0..(1 << ULID::TIMESTAMP_BITS));
-        let rand_part: u128 = rng.random_range(0..(1 << ULID::RANDOM_BITS));
-        ULID::from(time_part, rand_part)
+        let time_part: u64 = rng.random_range(0..(1 << Ulid::TIME_BITS));
+        let rand_part: u128 = rng.random_range(0..(1 << Ulid::RAND_BITS));
+        Ulid::from_parts(time_part, rand_part)
     }
 }

--- a/fake/src/lib.rs
+++ b/fake/src/lib.rs
@@ -13,6 +13,7 @@
 //! - `rust-decimal`: [rust_decimal](https://docs.rs/rust_decimal) integration
 //! - `time`: [time](https://docs.rs/time) integration
 //! - `ulid`: [ulid](https://docs.rs/ulid) integration
+//! - `ferroid`: [ferroid](https://docs.rs/ferroid) integration
 //! - `uuid`: [uuid](https://docs.rs/uuid) integration
 //!
 //! # Usage
@@ -268,6 +269,10 @@ pub use impls::geo;
 #[cfg(feature = "ulid")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ulid")))]
 pub use impls::ulid;
+
+#[cfg(feature = "ferroid")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ferroid")))]
+pub use impls::ferroid;
 
 #[cfg(feature = "uuid")]
 #[cfg_attr(docsrs, doc(cfg(feature = "uuid")))]

--- a/fake/tests/determinism.rs
+++ b/fake/tests/determinism.rs
@@ -225,7 +225,25 @@ check_determinism! { l10d Username; String, fake_username_en, fake_username_fr, 
 mod ulid {
     use fake::{Fake, Faker};
     use rand::SeedableRng as _;
-    check_determinism! { one fake_ulid, ulid::ULID, Faker }
+    check_determinism! { one fake_ulid, ulid::Ulid, Faker }
+}
+
+// it's sufficient to check one language, because it doesn't change anything
+#[cfg(feature = "ferroid")]
+mod ferroid {
+    use fake::ferroid::*;
+    use fake::{Fake, Faker};
+    use rand::SeedableRng as _;
+    check_determinism! { one fake_ferroid_ulid_f, ferroid::ULID, Faker }
+    check_determinism! { one fake_ferroid_ulid, ferroid::ULID, FerroidULID }
+    check_determinism! { one fake_ferroid_snowflake_twitter_f, ferroid::SnowflakeTwitterId, Faker }
+    check_determinism! { one fake_ferroid_snowflake_twitter, ferroid::SnowflakeTwitterId, FerroidTwitterId }
+    check_determinism! { one fake_ferroid_snowflake_mastodon_f, ferroid::SnowflakeMastodonId, Faker }
+    check_determinism! { one fake_ferroid_snowflake_mastodon, ferroid::SnowflakeMastodonId, FerroidMastodonId }
+    check_determinism! { one fake_ferroid_snowflake_discord_f, ferroid::SnowflakeDiscordId, Faker }
+    check_determinism! { one fake_ferroid_snowflake_discord, ferroid::SnowflakeDiscordId, FerroidDiscordId }
+    check_determinism! { one fake_ferroid_snowflake_instagram_f, ferroid::SnowflakeInstagramId, Faker }
+    check_determinism! { one fake_ferroid_snowflake_instagram, ferroid::SnowflakeInstagramId, FerroidInstagramId }
 }
 
 // it's sufficient to check one language, because it doesn't change anything


### PR DESCRIPTION
~~Replaces the [ulid](https://github.com/dylanhart/ulid-rs) crate with [ferroid](https://github.com/s0l0ist/ferroid), a drop-in alternative with identical behavior in this context.~~

~~There's no functional difference here, but `ferroid` provides a more modern foundation for ULID generation.~~

Adds [ferroid](https://github.com/s0l0ist/ferroid) ID types supporting ULID and Snowflake-like IDs.