### PR TITLE
Implement quiet flag to suppress generating info text

### DIFF
--- a/fake/src/bin/cli/main.rs
+++ b/fake/src/bin/cli/main.rs
@@ -1,4 +1,4 @@
-use clap::{command, value_parser, Arg};
+use clap::{command, value_parser, Arg, ArgAction};
 use rand::Rng;
 use std::io::{self, Write};
 
@@ -27,13 +27,14 @@ pub fn main() {
     let mut thread_rng = rand::rng();
     let args = cli_parser();
 
-    writeln!(
-        buf_stdout,
-        "Generating {} fakes for {:?} locale",
-        args.0.repeats, args.0.locale
-    )
-    .unwrap();
-
+    if !args.0.quiet {
+        writeln!(
+            buf_stdout,
+            "Generating {} fakes for {:?} locale",
+            args.0.repeats, args.0.locale
+        )
+        .unwrap();
+    }
     (0..args.0.repeats).for_each(|_| writeln!(buf_stdout, "{}", args.1(&mut thread_rng)).unwrap());
 }
 
@@ -77,6 +78,13 @@ fn cli_parser<R: Rng>() -> (Args, impl Fn(&mut R) -> String) {
                 .default_value("EN")
                 .value_parser(|value: &str| AVAILABLE_LOCALES::try_from(value)),
         )
+        .arg(
+            Arg::new("quiet")
+                .short('q')
+                .long("quiet")
+                .value_parser(value_parser!(bool))
+                .action(ArgAction::SetTrue),
+        )
         .subcommands(subcommands)
         .arg_required_else_help(true);
     let help_message = command.render_help();
@@ -86,12 +94,20 @@ fn cli_parser<R: Rng>() -> (Args, impl Fn(&mut R) -> String) {
         .get_one::<AVAILABLE_LOCALES>("locale")
         .unwrap()
         .to_owned();
-
+    let quiet = matches.get_flag("quiet");
     let fake_gen = fake_generator(matches, locale, help_message);
-    (Args { repeats, locale }, fake_gen)
+    (
+        Args {
+            repeats,
+            locale,
+            quiet,
+        },
+        fake_gen,
+    )
 }
 
 struct Args {
     repeats: u32,
     locale: AVAILABLE_LOCALES,
+    quiet: bool,
 }


### PR DESCRIPTION
I was finding a CLI tool to generate fake data and found this project! It's useful. But I found one small issue. I can't use it in shell scripts unless I do further processing. Because there's a INFO log before the output. 

For example:

```shell
$ fake FileName
Generating 1 fakes for EN locale
high.mp4
```

I could remove the first line by piping the output into `tail` command.

```shell
fake FileName | tail -n +2
high.mp4
```

This `--quiet` or `-q` flag would be convenient when using in shell scripts where only the generated data is needed.

For example:

```shell
touch $(fake --quiet FileName)
```

The implementation is also relatively simple with small amount of code changes.
Thank you very much for maintaining this library!