### PR TITLE
chore: bump rand(_core, _chacha) to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayvec"
@@ -162,7 +162,7 @@ dependencies = [
  "indexmap",
  "js-sys",
  "once_cell",
- "rand",
+ "rand 0.9.2",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
@@ -205,6 +205,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,18 +238,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.58"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.58"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -263,6 +274,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crypto-common"
@@ -398,9 +418,8 @@ dependencies = [
  "num-traits",
  "paste",
  "proptest",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.10.0",
+ "rand_core 0.10.0",
  "random_color",
  "rust_decimal",
  "semver",
@@ -511,6 +530,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -910,7 +930,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -945,7 +965,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -955,7 +986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -968,12 +999,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -982,7 +1019,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d635c5e80ae160390ac62ca027d2d06c94c1dc69e5c0a12f1e3a53664dc84966"
 dependencies = [
- "rand",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -1105,9 +1142,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1184,7 +1221,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand",
+ "rand 0.9.2",
  "web-time",
 ]
 

--- a/dummy_derive/src/lib.rs
+++ b/dummy_derive/src/lib.rs
@@ -91,7 +91,7 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
             ast::Style::Unit => {
                 let impl_dummy = quote! {
                     impl #impl_generics #crate_name::Dummy<#crate_name::Faker> for #receiver_name #ty_generics #where_clause {
-                        fn dummy_with_rng<R: #crate_name::Rng + ?Sized>(_: &#crate_name::Faker, rng: &mut R) -> Self {
+                        fn dummy_with_rng<R: #crate_name::RngExt + ?Sized>(_: &#crate_name::Faker, rng: &mut R) -> Self {
                             #receiver_name
                         }
                     }
@@ -106,7 +106,7 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
 
                 let impl_dummy = quote! {
                     impl #impl_generics #crate_name::Dummy<#crate_name::Faker> for #receiver_name #ty_generics #where_clause {
-                        fn dummy_with_rng<R: #crate_name::Rng + ?Sized>(_: &#crate_name::Faker, rng: &mut R) -> Self {
+                        fn dummy_with_rng<R: #crate_name::RngExt + ?Sized>(_: &#crate_name::Faker, rng: &mut R) -> Self {
                             #receiver_name(#(#tuple_fields),*)
                         }
                     }
@@ -131,7 +131,7 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
 
                 let impl_dummy = quote! {
                     impl #impl_generics #crate_name::Dummy<#crate_name::Faker> for #receiver_name #ty_generics #where_clause  {
-                        fn dummy_with_rng<R: #crate_name::Rng + ?Sized>(_: &#crate_name::Faker, rng: &mut R) -> Self {
+                        fn dummy_with_rng<R: #crate_name::RngExt + ?Sized>(_: &#crate_name::Faker, rng: &mut R) -> Self {
                             #(#let_statements)*
                             #receiver_name {
                                 #(#struct_fields),*
@@ -215,7 +215,7 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
 
                 let impl_dummy = quote! {
                     impl #impl_generics #crate_name::Dummy<#crate_name::Faker> for #receiver_name #ty_generics #where_clause {
-                        fn dummy_with_rng<R: #crate_name::Rng + ?Sized>(_: &#crate_name::Faker, rng: &mut R) -> Self {
+                        fn dummy_with_rng<R: #crate_name::RngExt + ?Sized>(_: &#crate_name::Faker, rng: &mut R) -> Self {
                             let options = [#(#variant_opts),*];
                             match #crate_name::rand::seq::IndexedRandom::choose(
                                 <_ as ::std::convert::AsRef<[usize]>>::as_ref(&options),
@@ -236,7 +236,7 @@ pub fn derive_dummy(input: TokenStream) -> TokenStream {
             } else {
                 let impl_dummy = quote! {
                     impl #impl_generics #crate_name::Dummy<#crate_name::Faker> for #receiver_name #ty_generics #where_clause {
-                        fn dummy_with_rng<R: #crate_name::Rng + ?Sized>(_: &#crate_name::Faker, rng: &mut R) -> Self {
+                        fn dummy_with_rng<R: #crate_name::RngExt + ?Sized>(_: &#crate_name::Faker, rng: &mut R) -> Self {
                             panic!("can not create an empty enum")
                         }
                     }

--- a/fake/Cargo.toml
+++ b/fake/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 dummy = { version = "0.11", path = "../dummy_derive", optional = true }
-rand = "0.9"
+rand = { version = "0.10", features = ["chacha"] }
 random_color = { version = "1", optional = true }
 deunicode = "1.6"
 chrono = { version = "0.4", features = [
@@ -45,7 +45,7 @@ num-traits = { version = "0.2", optional = true }
 rust_decimal = { version = "1.37", default-features = false, optional = true }
 bigdecimal-rs = { version = "0.4", package = "bigdecimal", default-features = false, optional = true }
 zerocopy = { version = "0.8", optional = true }
-rand_core = { version = "0.9", optional = true }
+rand_core = { version = "0.10", optional = true }
 glam = { version = ">=0.32", optional = true }
 url-escape = { version = "0.1", optional = true }
 bson = { version = "2", optional = true }
@@ -60,7 +60,6 @@ chrono = { version = "0.4", features = ["clock"], default-features = false }
 fake = { path = ".", features = ["derive"] }
 paste = "1"
 proptest = { version = "1", features = ["std"], default-features = false }
-rand_chacha = "0.9.0"
 
 [features]
 default = ["either"]

--- a/fake/src/bin/cli/fake_gen.rs
+++ b/fake/src/bin/cli/fake_gen.rs
@@ -1,6 +1,6 @@
 use clap::{builder::StyledStr, ArgMatches};
 use fake::{faker, Fake};
-use rand::Rng;
+use rand::RngExt;
 #[derive(Clone, Copy, Debug)]
 #[allow(non_camel_case_types)]
 pub enum AVAILABLE_LOCALES {
@@ -148,7 +148,7 @@ macro_rules! fakegen_commands {
     };
 }
 
-pub fn all_fakegen_commands<R: Rng>() -> (
+pub fn all_fakegen_commands<R: RngExt + ?Sized>() -> (
     Vec<Command>,
     impl Fn(ArgMatches, AVAILABLE_LOCALES, StyledStr) -> Box<dyn Fn(&mut R) -> String>,
 ) {

--- a/fake/src/bin/cli/main.rs
+++ b/fake/src/bin/cli/main.rs
@@ -1,5 +1,5 @@
 use clap::{command, value_parser, Arg, ArgAction};
-use rand::Rng;
+use rand::RngExt;
 use std::io::{self, Write};
 
 mod fake_gen;
@@ -53,7 +53,7 @@ impl TryFrom<&str> for AVAILABLE_LOCALES {
     }
 }
 
-fn cli_parser<R: Rng>() -> (Args, impl Fn(&mut R) -> String) {
+fn cli_parser<R: RngExt + ?Sized>() -> (Args, impl Fn(&mut R) -> String) {
     let (subcommands, fake_generator) = all_fakegen_commands::<R>();
     let mut command = command!()
         .arg(

--- a/fake/src/faker/impls/address.rs
+++ b/fake/src/faker/impls/address.rs
@@ -4,7 +4,7 @@ use crate::faker::numerify_sym;
 use crate::locales::Data;
 use crate::{Dummy, Fake, Faker};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 
 const ADDRESS_ZIP_CODE_CHARS: [char; 23] = [
     'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V',
@@ -12,7 +12,7 @@ const ADDRESS_ZIP_CODE_CHARS: [char; 23] = [
 ];
 
 #[inline]
-pub(crate) fn numerify_zip_code<R: Rng + ?Sized>(string: &str, rng: &mut R) -> String {
+pub(crate) fn numerify_zip_code<R: RngExt + ?Sized>(string: &str, rng: &mut R) -> String {
     string
         .chars()
         .map(|x| match x {
@@ -24,33 +24,33 @@ pub(crate) fn numerify_zip_code<R: Rng + ?Sized>(string: &str, rng: &mut R) -> S
 }
 
 impl<L: Data> Dummy<CityPrefix<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CityPrefix<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CityPrefix<L>, rng: &mut R) -> Self {
         let s = *L::ADDRESS_CITY_PREFIX.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<CityPrefix<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CityPrefix<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CityPrefix<L>, rng: &mut R) -> Self {
         L::ADDRESS_CITY_PREFIX.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<CitySuffix<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CitySuffix<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CitySuffix<L>, rng: &mut R) -> Self {
         let s = *L::ADDRESS_CITY_SUFFIX.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<CitySuffix<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CitySuffix<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CitySuffix<L>, rng: &mut R) -> Self {
         L::ADDRESS_CITY_SUFFIX.choose(rng).unwrap()
     }
 }
 
 pub trait CityNameGenFn: Data + Sized + Copy {
-    fn gen<R: Rng + ?Sized>(c: &CityName<Self>, rng: &mut R) -> String {
+    fn gen<R: RngExt + ?Sized>(c: &CityName<Self>, rng: &mut R) -> String {
         match (0..5).fake_with_rng::<u8, _>(rng) {
             0 => Self::ADDRESS_CITY_WITH_PREFIX_TPL
                 .replace(
@@ -83,52 +83,52 @@ pub trait CityNameGenFn: Data + Sized + Copy {
 
 impl<L: CityNameGenFn> Dummy<CityName<L>> for String {
     #[inline(always)]
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &CityName<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &CityName<L>, rng: &mut R) -> Self {
         L::gen(c, rng)
     }
 }
 
 impl<L: Data> Dummy<CountryName<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CountryName<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CountryName<L>, rng: &mut R) -> Self {
         let s = *L::ADDRESS_COUNTRY.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<CountryName<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CountryName<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CountryName<L>, rng: &mut R) -> Self {
         L::ADDRESS_COUNTRY.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<CountryCode<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CountryCode<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CountryCode<L>, rng: &mut R) -> Self {
         let s = *L::ADDRESS_COUNTRY_CODE.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<CountryCode<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CountryCode<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CountryCode<L>, rng: &mut R) -> Self {
         L::ADDRESS_COUNTRY_CODE.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<StreetSuffix<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &StreetSuffix<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &StreetSuffix<L>, rng: &mut R) -> Self {
         let s = *L::ADDRESS_STREET_SUFFIX.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<StreetSuffix<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &StreetSuffix<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &StreetSuffix<L>, rng: &mut R) -> Self {
         L::ADDRESS_STREET_SUFFIX.choose(rng).unwrap()
     }
 }
 
 impl<L: Data + Copy> Dummy<StreetName<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &StreetName<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &StreetName<L>, rng: &mut R) -> Self {
         let name = if Faker.fake_with_rng::<bool, _>(rng) {
             FirstName(c.0).fake_with_rng::<&str, _>(rng)
         } else {
@@ -142,59 +142,59 @@ impl<L: Data + Copy> Dummy<StreetName<L>> for String {
 }
 
 impl<L: Data> Dummy<TimeZone<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &TimeZone<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &TimeZone<L>, rng: &mut R) -> Self {
         let s = *L::ADDRESS_TIME_ZONE.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<TimeZone<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &TimeZone<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &TimeZone<L>, rng: &mut R) -> Self {
         L::ADDRESS_TIME_ZONE.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<StateName<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &StateName<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &StateName<L>, rng: &mut R) -> Self {
         let s = *L::ADDRESS_STATE.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<StateName<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &StateName<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &StateName<L>, rng: &mut R) -> Self {
         L::ADDRESS_STATE.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<StateAbbr<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &StateAbbr<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &StateAbbr<L>, rng: &mut R) -> Self {
         let s = *L::ADDRESS_STATE_ABBR.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<StateAbbr<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &StateAbbr<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &StateAbbr<L>, rng: &mut R) -> Self {
         L::ADDRESS_STATE_ABBR.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<SecondaryAddressType<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &SecondaryAddressType<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &SecondaryAddressType<L>, rng: &mut R) -> Self {
         let s = *L::ADDRESS_SECONDARY_ADDR_TYPE.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<SecondaryAddressType<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &SecondaryAddressType<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &SecondaryAddressType<L>, rng: &mut R) -> Self {
         L::ADDRESS_SECONDARY_ADDR_TYPE.choose(rng).unwrap()
     }
 }
 
 impl<L: Data + Copy> Dummy<SecondaryAddress<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &SecondaryAddress<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &SecondaryAddress<L>, rng: &mut R) -> Self {
         L::ADDRESS_SECONDARY_ADDR_TPL
             .replace(
                 "{SecondaryAddrType}",
@@ -208,21 +208,21 @@ impl<L: Data + Copy> Dummy<SecondaryAddress<L>> for String {
 }
 
 impl<L: Data + Copy> Dummy<ZipCode<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &ZipCode<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &ZipCode<L>, rng: &mut R) -> Self {
         let fmt = L::ADDRESS_ZIP_FORMATS.choose(rng).unwrap();
         numerify_zip_code(fmt, rng)
     }
 }
 
 impl<L: Data + Copy> Dummy<PostCode<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &PostCode<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &PostCode<L>, rng: &mut R) -> Self {
         let fmt = L::ADDRESS_POSTCODE_FORMATS.choose(rng).unwrap();
         numerify_zip_code(fmt, rng)
     }
 }
 
 impl<L: Data + Copy> Dummy<BuildingNumber<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &BuildingNumber<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &BuildingNumber<L>, rng: &mut R) -> Self {
         let fmt = L::ADDRESS_BUILDING_NUMBER_FORMATS.choose(rng).unwrap();
         numerify_sym(fmt, rng)
     }
@@ -230,51 +230,51 @@ impl<L: Data + Copy> Dummy<BuildingNumber<L>> for String {
 
 impl<L: Data> Dummy<Latitude<L>> for f64 {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Latitude<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Latitude<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng::<f64, _>(rng) * 180_f64 - 90_f64
     }
 }
 
 impl<L: Data> Dummy<Latitude<L>> for f32 {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Latitude<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Latitude<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng::<f32, _>(rng) * 360_f32 - 90_f32
     }
 }
 
 impl<L: Data> Dummy<Latitude<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Latitude<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Latitude<L>, rng: &mut R) -> Self {
         c.fake_with_rng::<f64, _>(rng).to_string()
     }
 }
 
 impl<L: Data> Dummy<Longitude<L>> for f64 {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Longitude<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Longitude<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng::<f64, _>(rng) * 360_f64 - 90_f64
     }
 }
 
 impl<L: Data> Dummy<Longitude<L>> for f32 {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Longitude<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Longitude<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng::<f32, _>(rng) * 360_f32 - 90_f32
     }
 }
 
 impl<L: Data> Dummy<Longitude<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Longitude<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Longitude<L>, rng: &mut R) -> Self {
         c.fake_with_rng::<f32, _>(rng).to_string()
     }
 }
 
 impl<L: Data> Dummy<Geohash<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(g: &Geohash<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(g: &Geohash<L>, rng: &mut R) -> Self {
         L::ADDRESS_GEOHASH_CHARS
-            .choose_multiple(rng, g.1 as usize)
+            .sample(rng, g.1 as usize)
             .cloned()
             .collect()
     }

--- a/fake/src/faker/impls/administrative.rs
+++ b/fake/src/faker/impls/administrative.rs
@@ -2,7 +2,7 @@ use crate::faker::administrative::raw::*;
 use crate::locales::FR_FR;
 use crate::{Dummy, Fake};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 
 // ref https://fr.wikipedia.org/wiki/Num%C3%A9rotation_des_d%C3%A9partements_fran%C3%A7ais
 const FR_FR_DEPARTMENTS: &[&str] = &[
@@ -16,7 +16,7 @@ const FR_FR_DEPARTMENTS: &[&str] = &[
 ];
 
 impl Dummy<HealthInsuranceCode<FR_FR>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &HealthInsuranceCode<FR_FR>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &HealthInsuranceCode<FR_FR>, rng: &mut R) -> Self {
         // ref https://www.previssima.fr/lexique/numero-de-securite-sociale-a-13-chiffres.html
         // and test on http://marlot.org/util/calcul-de-la-cle-nir.php
         let sex: u8 = (1..3).fake_with_rng::<u8, _>(rng);

--- a/fake/src/faker/impls/automotive.rs
+++ b/fake/src/faker/impls/automotive.rs
@@ -2,7 +2,7 @@ use crate::faker::automotive::raw::*;
 use crate::locales::{FR_FR, IT_IT, NL_NL};
 use crate::{Dummy, Fake};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 use std::char;
 /* ABC without I, O and U
 As with the SIV system, The letters I and O were never used because they could be confused with other characters, like 1 and 0.
@@ -17,7 +17,7 @@ const LICENSE_CHARS: [char; 23] = [
 ];
 
 #[inline]
-pub(crate) fn numerify_licence_plate<R: Rng + ?Sized>(string: &str, rng: &mut R) -> String {
+pub(crate) fn numerify_licence_plate<R: RngExt + ?Sized>(string: &str, rng: &mut R) -> String {
     string
         .chars()
         .map(|x| match x {
@@ -31,14 +31,14 @@ pub(crate) fn numerify_licence_plate<R: Rng + ?Sized>(string: &str, rng: &mut R)
 const LICENSE_PLATE: &[&str] = &["$$-###-$$"];
 
 impl Dummy<LicencePlate<FR_FR>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &LicencePlate<FR_FR>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &LicencePlate<FR_FR>, rng: &mut R) -> Self {
         let fmt = LICENSE_PLATE.choose(rng).unwrap();
         numerify_licence_plate(fmt, rng)
     }
 }
 
 impl Dummy<LicencePlate<IT_IT>> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &LicencePlate<IT_IT>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &LicencePlate<IT_IT>, rng: &mut R) -> Self {
         let fmt = LICENSE_PLATE.choose(rng).unwrap();
         crate::faker::impls::automotive::numerify_licence_plate(fmt, rng)
     }
@@ -47,7 +47,7 @@ impl Dummy<LicencePlate<IT_IT>> for String {
 const NL_NL_LICENSE_PLATE: &[&str] = &["$$-###-$", "$-###-$$", "$$$-##-$"];
 
 impl Dummy<LicencePlate<NL_NL>> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &LicencePlate<NL_NL>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &LicencePlate<NL_NL>, rng: &mut R) -> Self {
         let fmt = NL_NL_LICENSE_PLATE.choose(rng).unwrap();
         numerify_licence_plate(fmt, rng)
     }

--- a/fake/src/faker/impls/barcode.rs
+++ b/fake/src/faker/impls/barcode.rs
@@ -4,7 +4,7 @@ use crate::faker::numerify_sym;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 
 const ISBN_MAX_LENGTH: usize = 13;
 
@@ -69,7 +69,7 @@ fn checksum13(properties: &IsbnProperties) -> i32 {
     check_digit
 }
 
-fn get_properties<L: Data, R: Rng + ?Sized>(_c: L, rng: &mut R) -> IsbnProperties {
+fn get_properties<L: Data, R: RngExt + ?Sized>(_c: L, rng: &mut R) -> IsbnProperties {
     let ean = L::ISBN_EAN;
     let rules = *L::isbn_rules();
     let keys: Vec<&'static str> = rules.keys().cloned().collect();
@@ -96,7 +96,7 @@ fn get_properties<L: Data, R: Rng + ?Sized>(_c: L, rng: &mut R) -> IsbnPropertie
 }
 
 impl<L: Data + Copy> Dummy<Isbn10<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Isbn10<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Isbn10<L>, rng: &mut R) -> Self {
         let properties = get_properties(c.0, rng);
         format!(
             "{}-{}-{}-{}",
@@ -109,7 +109,7 @@ impl<L: Data + Copy> Dummy<Isbn10<L>> for String {
 }
 
 impl<L: Data + Copy> Dummy<Isbn13<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Isbn13<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Isbn13<L>, rng: &mut R) -> Self {
         let properties = get_properties(c.0, rng);
         format!(
             "{}-{}-{}-{}-{}",
@@ -123,7 +123,7 @@ impl<L: Data + Copy> Dummy<Isbn13<L>> for String {
 }
 
 impl<L: Data + Copy> Dummy<Isbn<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Isbn<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Isbn<L>, rng: &mut R) -> Self {
         if Boolean(c.0, 50).fake_with_rng(rng) {
             return Isbn13(c.0).fake_with_rng(rng);
         }

--- a/fake/src/faker/impls/boolean.rs
+++ b/fake/src/faker/impls/boolean.rs
@@ -1,10 +1,10 @@
 use crate::faker::boolean::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
-use rand::Rng;
+use rand::RngExt;
 
 impl<L: Data> Dummy<Boolean<L>> for bool {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Boolean<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Boolean<L>, rng: &mut R) -> Self {
         let w: u8 = (0..100).fake_with_rng(rng);
         w < c.1
     }

--- a/fake/src/faker/impls/chrono.rs
+++ b/fake/src/faker/impls/chrono.rs
@@ -2,20 +2,20 @@ use crate::faker::chrono::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake, Faker};
 use chrono::{TimeZone, Utc};
-use rand::Rng;
+use rand::RngExt;
 
 const MINUTES_MAX_BOUND: i64 = 1_000_000;
 
 impl<L: Data> Dummy<Time<L>> for chrono::NaiveTime {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Time<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Time<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng(rng)
     }
 }
 
 impl<L: Data> Dummy<Time<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Time<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Time<L>, rng: &mut R) -> Self {
         let time: chrono::NaiveTime = Faker.fake_with_rng(rng);
         time.format(L::CHRONO_DEFAULT_TIME_FORMAT).to_string()
     }
@@ -23,14 +23,14 @@ impl<L: Data> Dummy<Time<L>> for String {
 
 impl<L: Data> Dummy<Date<L>> for chrono::NaiveDate {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Date<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Date<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng(rng)
     }
 }
 
 impl<L: Data> Dummy<Date<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Date<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Date<L>, rng: &mut R) -> Self {
         let date: chrono::NaiveDate = Faker.fake_with_rng(rng);
         date.format(L::CHRONO_DEFAULT_DATE_FORMAT).to_string()
     }
@@ -38,21 +38,21 @@ impl<L: Data> Dummy<Date<L>> for String {
 
 impl<L: Data> Dummy<DateTime<L>> for chrono::NaiveDateTime {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng(rng)
     }
 }
 
 impl<L: Data, Tz: TimeZone + Dummy<Faker>> Dummy<DateTime<L>> for chrono::DateTime<Tz> {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng(rng)
     }
 }
 
 impl<L: Data> Dummy<DateTime<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
         let datetime: chrono::DateTime<Utc> = Faker.fake_with_rng(rng);
         datetime
             .format(L::CHRONO_DEFAULT_DATETIME_FORMAT)
@@ -62,13 +62,13 @@ impl<L: Data> Dummy<DateTime<L>> for String {
 
 impl<L: Data> Dummy<Duration<L>> for chrono::Duration {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Duration<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Duration<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng(rng)
     }
 }
 
 impl<L: Data> Dummy<DateTimeBefore<L>> for chrono::DateTime<Utc> {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeBefore<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &DateTimeBefore<L>, rng: &mut R) -> Self {
         let mins: i64 = (1..MINUTES_MAX_BOUND).fake_with_rng(rng);
         let duration = chrono::Duration::minutes(mins);
         c.1 - duration
@@ -76,7 +76,7 @@ impl<L: Data> Dummy<DateTimeBefore<L>> for chrono::DateTime<Utc> {
 }
 
 impl<L: Data> Dummy<DateTimeBefore<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeBefore<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &DateTimeBefore<L>, rng: &mut R) -> Self {
         let datetime: chrono::DateTime<Utc> = c.fake_with_rng(rng);
         datetime
             .format(L::CHRONO_DEFAULT_DATETIME_FORMAT)
@@ -85,7 +85,7 @@ impl<L: Data> Dummy<DateTimeBefore<L>> for String {
 }
 
 impl<L: Data> Dummy<DateTimeAfter<L>> for chrono::DateTime<Utc> {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeAfter<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &DateTimeAfter<L>, rng: &mut R) -> Self {
         let mins: i64 = (1..MINUTES_MAX_BOUND).fake_with_rng(rng);
         let duration = chrono::Duration::minutes(mins);
         c.1 + duration
@@ -94,7 +94,7 @@ impl<L: Data> Dummy<DateTimeAfter<L>> for chrono::DateTime<Utc> {
 
 impl<L: Data> Dummy<DateTimeAfter<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeAfter<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &DateTimeAfter<L>, rng: &mut R) -> Self {
         let datetime: chrono::DateTime<Utc> = c.fake_with_rng(rng);
         datetime
             .format(L::CHRONO_DEFAULT_DATETIME_FORMAT)
@@ -104,7 +104,7 @@ impl<L: Data> Dummy<DateTimeAfter<L>> for String {
 
 impl<L: Data> Dummy<DateTimeBetween<L>> for chrono::DateTime<Utc> {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeBetween<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &DateTimeBetween<L>, rng: &mut R) -> Self {
         let diff = c.2 - c.1;
         let max_minutes = diff.num_minutes();
 
@@ -116,7 +116,7 @@ impl<L: Data> Dummy<DateTimeBetween<L>> for chrono::DateTime<Utc> {
 
 impl<L: Data> Dummy<DateTimeBetween<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeBetween<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &DateTimeBetween<L>, rng: &mut R) -> Self {
         let datetime: chrono::DateTime<Utc> = c.fake_with_rng(rng);
         datetime
             .format(L::CHRONO_DEFAULT_DATETIME_FORMAT)

--- a/fake/src/faker/impls/color.rs
+++ b/fake/src/faker/impls/color.rs
@@ -1,11 +1,11 @@
 use crate::faker::color::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 
 impl<L: Data> Dummy<HexColor<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &HexColor<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &HexColor<L>, rng: &mut R) -> Self {
         let mut color: random_color::RandomColor = Faker.fake_with_rng(rng);
         color.to_hex()
     }
@@ -13,7 +13,7 @@ impl<L: Data> Dummy<HexColor<L>> for String {
 
 impl<L: Data> Dummy<RgbColor<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &RgbColor<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &RgbColor<L>, rng: &mut R) -> Self {
         let mut color: random_color::RandomColor = Faker.fake_with_rng(rng);
         color.to_rgb_string()
     }
@@ -21,7 +21,7 @@ impl<L: Data> Dummy<RgbColor<L>> for String {
 
 impl<L: Data> Dummy<RgbaColor<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &RgbaColor<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &RgbaColor<L>, rng: &mut R) -> Self {
         let mut color: random_color::RandomColor = Faker.fake_with_rng(rng);
         color.to_rgba_string()
     }
@@ -29,7 +29,7 @@ impl<L: Data> Dummy<RgbaColor<L>> for String {
 
 impl<L: Data> Dummy<HslColor<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &HslColor<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &HslColor<L>, rng: &mut R) -> Self {
         let mut color: random_color::RandomColor = Faker.fake_with_rng(rng);
         color.to_hsl_string()
     }
@@ -37,7 +37,7 @@ impl<L: Data> Dummy<HslColor<L>> for String {
 
 impl<L: Data> Dummy<HslaColor<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &HslaColor<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &HslaColor<L>, rng: &mut R) -> Self {
         let mut color: random_color::RandomColor = Faker.fake_with_rng(rng);
         color.to_hsla_string()
     }
@@ -45,7 +45,7 @@ impl<L: Data> Dummy<HslaColor<L>> for String {
 
 impl<L: Data> Dummy<Color<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Color<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Color<L>, rng: &mut R) -> Self {
         let mut _color: random_color::RandomColor = Faker.fake_with_rng(rng);
         format!(
             "{}\n{}\n{}\n{}\n{}",

--- a/fake/src/faker/impls/company.rs
+++ b/fake/src/faker/impls/company.rs
@@ -3,23 +3,23 @@ use crate::faker::name::raw::LastName;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 
 impl<L: Data> Dummy<CompanySuffix<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CompanySuffix<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CompanySuffix<L>, rng: &mut R) -> Self {
         let s = *L::COMPANY_SUFFIX.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<CompanySuffix<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CompanySuffix<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CompanySuffix<L>, rng: &mut R) -> Self {
         L::COMPANY_SUFFIX.choose(rng).unwrap()
     }
 }
 
 impl<L: Data + Copy> Dummy<CompanyName<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &CompanyName<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &CompanyName<L>, rng: &mut R) -> Self {
         let name_tpl = *L::COMPANY_NAME_TPLS.choose(rng).unwrap();
         name_tpl
             .replace("{Name_1}", LastName(c.0).fake_with_rng::<&str, _>(rng))
@@ -29,46 +29,46 @@ impl<L: Data + Copy> Dummy<CompanyName<L>> for String {
 }
 
 impl<L: Data> Dummy<Buzzword<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Buzzword<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Buzzword<L>, rng: &mut R) -> Self {
         let s = *L::COMPANY_BUZZWORD_HEAD.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<Buzzword<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Buzzword<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Buzzword<L>, rng: &mut R) -> Self {
         L::COMPANY_BUZZWORD_HEAD.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<BuzzwordMiddle<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &BuzzwordMiddle<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &BuzzwordMiddle<L>, rng: &mut R) -> Self {
         let s = *L::COMPANY_BUZZWORD_MIDDLE.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<BuzzwordMiddle<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &BuzzwordMiddle<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &BuzzwordMiddle<L>, rng: &mut R) -> Self {
         L::COMPANY_BUZZWORD_MIDDLE.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<BuzzwordTail<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &BuzzwordTail<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &BuzzwordTail<L>, rng: &mut R) -> Self {
         let s = *L::COMPANY_BUZZWORD_TAIL.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<BuzzwordTail<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &BuzzwordTail<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &BuzzwordTail<L>, rng: &mut R) -> Self {
         L::COMPANY_BUZZWORD_TAIL.choose(rng).unwrap()
     }
 }
 
 impl<L: Data + Copy> Dummy<CatchPhrase<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &CatchPhrase<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &CatchPhrase<L>, rng: &mut R) -> Self {
         L::COMPANY_CATCH_PHASE_TPL
             .replace("{Head}", Buzzword(c.0).fake_with_rng::<&str, _>(rng))
             .replace(
@@ -80,46 +80,46 @@ impl<L: Data + Copy> Dummy<CatchPhrase<L>> for String {
 }
 
 impl<L: Data> Dummy<BsVerb<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &BsVerb<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &BsVerb<L>, rng: &mut R) -> Self {
         let s = *L::COMPANY_BS_VERBS.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<BsVerb<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &BsVerb<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &BsVerb<L>, rng: &mut R) -> Self {
         L::COMPANY_BS_VERBS.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<BsAdj<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &BsAdj<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &BsAdj<L>, rng: &mut R) -> Self {
         let s = *L::COMPANY_BS_ADJ.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<BsAdj<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &BsAdj<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &BsAdj<L>, rng: &mut R) -> Self {
         L::COMPANY_BS_ADJ.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<BsNoun<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &BsNoun<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &BsNoun<L>, rng: &mut R) -> Self {
         let s = *L::COMPANY_BS_NOUNS.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<BsNoun<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &BsNoun<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &BsNoun<L>, rng: &mut R) -> Self {
         L::COMPANY_BS_NOUNS.choose(rng).unwrap()
     }
 }
 
 impl<L: Data + Copy> Dummy<Bs<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Bs<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Bs<L>, rng: &mut R) -> Self {
         L::COMPANY_BS_TPL
             .replace("{Verb}", BsVerb(c.0).fake_with_rng::<&str, _>(rng))
             .replace("{Adj}", BsAdj(c.0).fake_with_rng::<&str, _>(rng))
@@ -128,27 +128,27 @@ impl<L: Data + Copy> Dummy<Bs<L>> for String {
 }
 
 impl<L: Data> Dummy<Profession<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Profession<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Profession<L>, rng: &mut R) -> Self {
         let s = *L::COMPANY_PROFESSION.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<Profession<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Profession<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Profession<L>, rng: &mut R) -> Self {
         L::COMPANY_PROFESSION.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<Industry<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Industry<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Industry<L>, rng: &mut R) -> Self {
         let s = *L::COMPANY_INDUSTRY.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<Industry<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Industry<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Industry<L>, rng: &mut R) -> Self {
         L::COMPANY_INDUSTRY.choose(rng).unwrap()
     }
 }

--- a/fake/src/faker/impls/creditcard.rs
+++ b/fake/src/faker/impls/creditcard.rs
@@ -2,7 +2,7 @@ use crate::faker::creditcard::raw::CreditCardNumber;
 use crate::locales::Data;
 use crate::Dummy;
 use rand::seq::{IndexedRandom, IteratorRandom};
-use rand::Rng;
+use rand::RngExt;
 
 type PrefixCreditcard<'a> = (u8, Option<&'a [u8]>, &'a [usize]);
 
@@ -13,7 +13,7 @@ static PREFIX_LENGTHS: &[PrefixCreditcard] = &[
 ];
 
 impl<L: Data> Dummy<CreditCardNumber<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CreditCardNumber<L>, rng: &mut R) -> String {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CreditCardNumber<L>, rng: &mut R) -> String {
         let (prefix, opt_prefix, lens): PrefixCreditcard = *PREFIX_LENGTHS.choose(rng).unwrap();
         let len = *lens.choose(rng).unwrap();
         let mut bytes = vec![prefix];

--- a/fake/src/faker/impls/currency.rs
+++ b/fake/src/faker/impls/currency.rs
@@ -2,43 +2,43 @@ use crate::faker::currency::raw::*;
 use crate::locales::Data;
 use crate::Dummy;
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 
 impl<L: Data> Dummy<CurrencyCode<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CurrencyCode<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CurrencyCode<L>, rng: &mut R) -> Self {
         let s = *L::CURRENCY_CODE.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<CurrencyCode<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CurrencyCode<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CurrencyCode<L>, rng: &mut R) -> Self {
         L::CURRENCY_CODE.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<CurrencyName<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CurrencyName<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CurrencyName<L>, rng: &mut R) -> Self {
         let s = *L::CURRENCY_NAME.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<CurrencyName<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CurrencyName<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CurrencyName<L>, rng: &mut R) -> Self {
         L::CURRENCY_NAME.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<CurrencySymbol<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CurrencySymbol<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CurrencySymbol<L>, rng: &mut R) -> Self {
         let s = *L::CURRENCY_SYMBOL.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<CurrencySymbol<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &CurrencySymbol<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &CurrencySymbol<L>, rng: &mut R) -> Self {
         L::CURRENCY_SYMBOL.choose(rng).unwrap()
     }
 }

--- a/fake/src/faker/impls/filesystem.rs
+++ b/fake/src/faker/impls/filesystem.rs
@@ -4,7 +4,7 @@ use crate::impls::std::path::PathFaker;
 use crate::locales::{Data, EN};
 use crate::{Dummy, Fake};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 use std::path::PathBuf;
 
 const MIME_TYPES: &[&str] = &[
@@ -1871,14 +1871,14 @@ const MIME_TYPES: &[&str] = &[
 ];
 
 impl<L: Data> Dummy<FilePath<L>> for PathBuf {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &FilePath<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &FilePath<L>, rng: &mut R) -> Self {
         let faker = PathFaker::new(L::PATH_ROOT_DIRS, L::PATH_SEGMENTS, L::PATH_EXTENSIONS, 4);
         faker.fake_with_rng(rng)
     }
 }
 
 impl<L: Data> Dummy<FilePath<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &FilePath<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &FilePath<L>, rng: &mut R) -> Self {
         let faker = PathFaker::new(L::PATH_ROOT_DIRS, L::PATH_SEGMENTS, L::PATH_EXTENSIONS, 4);
         let p: PathBuf = faker.fake_with_rng(rng);
         p.to_string_lossy().into()
@@ -1886,7 +1886,7 @@ impl<L: Data> Dummy<FilePath<L>> for String {
 }
 
 impl<L: Data> Dummy<FileName<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &FileName<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &FileName<L>, rng: &mut R) -> Self {
         let name = L::PATH_SEGMENTS.choose(rng).unwrap();
         let ext = L::PATH_EXTENSIONS.choose(rng).unwrap();
         format!("{name}.{ext}")
@@ -1894,27 +1894,27 @@ impl<L: Data> Dummy<FileName<L>> for String {
 }
 
 impl<L: Data> Dummy<FileExtension<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &FileExtension<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &FileExtension<L>, rng: &mut R) -> Self {
         L::PATH_EXTENSIONS.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<FileExtension<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &FileExtension<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &FileExtension<L>, rng: &mut R) -> Self {
         let ext = L::PATH_EXTENSIONS.choose(rng).unwrap();
         (*ext).to_string()
     }
 }
 
 impl<L: Data> Dummy<DirPath<L>> for PathBuf {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &DirPath<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &DirPath<L>, rng: &mut R) -> Self {
         let faker = PathFaker::new(L::PATH_ROOT_DIRS, L::PATH_SEGMENTS, &[], 4);
         faker.fake_with_rng(rng)
     }
 }
 
 impl<L: Data> Dummy<DirPath<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &DirPath<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &DirPath<L>, rng: &mut R) -> Self {
         let faker = PathFaker::new(L::PATH_ROOT_DIRS, L::PATH_SEGMENTS, &[], 4);
         let p: PathBuf = faker.fake_with_rng(rng);
         p.to_string_lossy().into()
@@ -1924,7 +1924,7 @@ impl<L: Data> Dummy<DirPath<L>> for String {
 const UNSTABLE_SEMVER: &[&str] = &["alpha", "beta", "rc"];
 
 impl<L: Data + Copy> Dummy<Semver<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Semver<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Semver<L>, rng: &mut R) -> Self {
         let probability = 10;
         if Boolean(EN, probability).fake_with_rng(rng) {
             return SemverUnstable(c.0).fake_with_rng(rng);
@@ -1934,7 +1934,7 @@ impl<L: Data + Copy> Dummy<Semver<L>> for String {
 }
 
 impl<L: Data> Dummy<SemverStable<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &SemverStable<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &SemverStable<L>, rng: &mut R) -> Self {
         let patch = &mut (0..20).fake_with_rng::<u8, _>(rng).to_string();
         format!(
             "{}.{}.{}",
@@ -1946,7 +1946,7 @@ impl<L: Data> Dummy<SemverStable<L>> for String {
 }
 
 impl<L: Data> Dummy<SemverUnstable<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &SemverUnstable<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &SemverUnstable<L>, rng: &mut R) -> Self {
         let patch = &mut (0..20).fake_with_rng::<u8, _>(rng).to_string();
         patch.push_str(&format!(
             "-{}.{}",
@@ -1963,7 +1963,7 @@ impl<L: Data> Dummy<SemverUnstable<L>> for String {
 }
 
 impl<L: Data> Dummy<MimeType<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &MimeType<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &MimeType<L>, rng: &mut R) -> Self {
         MIME_TYPES.choose(rng).unwrap().to_string()
     }
 }

--- a/fake/src/faker/impls/finance.rs
+++ b/fake/src/faker/impls/finance.rs
@@ -2,7 +2,7 @@ use crate::faker::finance::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 
 const ALPHABET: &[char; 26] = &[
     'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
@@ -37,7 +37,7 @@ const ISO3166: &[&str] = &[
 const VOWELS: &[char; 5] = &['A', 'E', 'I', 'O', 'U'];
 
 impl<L: Data> Dummy<Bic<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Bic<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Bic<L>, rng: &mut R) -> Self {
         let prob: i8 = (0..100).fake_with_rng(rng);
         let suffix = if prob < 50 {
             return format!(
@@ -85,7 +85,7 @@ fn split_number_to_digits(x: u32) -> Vec<u32> {
 }
 
 impl<L: Data> Dummy<Isin<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Isin<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Isin<L>, rng: &mut R) -> Self {
         let country_code = *ISO3166.choose(rng).unwrap();
         let nsin = (1..10)
             .map(|_x| *ALPHANUMERIC.choose(rng).unwrap())

--- a/fake/src/faker/impls/http.rs
+++ b/fake/src/faker/impls/http.rs
@@ -1,18 +1,18 @@
 use crate::faker::http::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 
 impl<L: Data> Dummy<RfcStatusCode<L>> for http::StatusCode {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &RfcStatusCode<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &RfcStatusCode<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng(rng)
     }
 }
 
 impl<L: Data> Dummy<RfcStatusCode<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &RfcStatusCode<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &RfcStatusCode<L>, rng: &mut R) -> Self {
         let code: http::StatusCode = Faker.fake_with_rng(rng);
         format!("{}", code)
     }
@@ -20,7 +20,7 @@ impl<L: Data> Dummy<RfcStatusCode<L>> for String {
 
 impl<L: Data> Dummy<ValidStatusCode<L>> for http::StatusCode {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &ValidStatusCode<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &ValidStatusCode<L>, rng: &mut R) -> Self {
         let code: u16 = (100..600).fake_with_rng(rng);
         http::StatusCode::from_u16(code).unwrap()
     }
@@ -28,7 +28,7 @@ impl<L: Data> Dummy<ValidStatusCode<L>> for http::StatusCode {
 
 impl<L: Data> Dummy<ValidStatusCode<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &ValidStatusCode<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &ValidStatusCode<L>, rng: &mut R) -> Self {
         let code: u16 = (100..600).fake_with_rng(rng);
         format!("{}", http::StatusCode::from_u16(code).unwrap())
     }

--- a/fake/src/faker/impls/internet.rs
+++ b/fake/src/faker/impls/internet.rs
@@ -6,37 +6,37 @@ use crate::{Dummy, Fake, Faker};
 use deunicode::AsciiChars;
 use rand::distr::{Distribution, Uniform};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 impl<L: Data> Dummy<FreeEmailProvider<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &FreeEmailProvider<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &FreeEmailProvider<L>, rng: &mut R) -> Self {
         let s = *L::INTERNET_FREE_EMAIL_PROVIDER.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<FreeEmailProvider<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &FreeEmailProvider<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &FreeEmailProvider<L>, rng: &mut R) -> Self {
         L::INTERNET_FREE_EMAIL_PROVIDER.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<DomainSuffix<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &DomainSuffix<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &DomainSuffix<L>, rng: &mut R) -> Self {
         let s = *L::INTERNET_DOMAIN_SUFFIX.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<DomainSuffix<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &DomainSuffix<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &DomainSuffix<L>, rng: &mut R) -> Self {
         L::INTERNET_DOMAIN_SUFFIX.choose(rng).unwrap()
     }
 }
 
 impl<L: Data + Copy> Dummy<FreeEmail<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &FreeEmail<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &FreeEmail<L>, rng: &mut R) -> Self {
         let username: String = Username(c.0).fake_with_rng(rng);
         let provider: String = FreeEmailProvider(c.0).fake_with_rng(rng);
         format!("{}@{}", username.ascii_chars(), provider)
@@ -44,7 +44,7 @@ impl<L: Data + Copy> Dummy<FreeEmail<L>> for String {
 }
 
 impl<L: Data + Copy> Dummy<SafeEmail<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &SafeEmail<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &SafeEmail<L>, rng: &mut R) -> Self {
         let username: String = FirstName(c.0).fake_with_rng::<&str, _>(rng).to_lowercase();
         let domain = ["com", "net", "org"].choose(rng).unwrap();
         format!("{username}@example.{domain}")
@@ -52,7 +52,7 @@ impl<L: Data + Copy> Dummy<SafeEmail<L>> for String {
 }
 
 impl<L: Data + Copy> Dummy<Username<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Username<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Username<L>, rng: &mut R) -> Self {
         match Faker.fake_with_rng::<u8, _>(rng) {
             0 => FirstName(c.0).fake_with_rng::<&str, _>(rng).to_lowercase(),
             1 | 2 => format!(
@@ -75,7 +75,7 @@ impl<L: Data + Copy> Dummy<Username<L>> for String {
 }
 
 impl<L: Data> Dummy<Password<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Password<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Password<L>, rng: &mut R) -> Self {
         let len: usize = c.1.fake_with_rng(rng);
         let s: Option<String> = (0..len)
             .map(|_| Some(*L::INTERNET_PASSWORD_CHARS.choose(rng)?))
@@ -85,7 +85,7 @@ impl<L: Data> Dummy<Password<L>> for String {
 }
 
 impl<L: Data> Dummy<IPv4<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &IPv4<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &IPv4<L>, rng: &mut R) -> Self {
         let u = Uniform::new_inclusive(u8::MIN, u8::MAX).expect("u8::MIN <= u8::MAX");
         format!(
             "{}.{}.{}.{}",
@@ -99,13 +99,13 @@ impl<L: Data> Dummy<IPv4<L>> for String {
 
 impl<L: Data> Dummy<IPv4<L>> for Ipv4Addr {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &IPv4<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &IPv4<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng::<Ipv4Addr, _>(rng)
     }
 }
 
 impl<L: Data> Dummy<IPv6<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &IPv6<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &IPv6<L>, rng: &mut R) -> Self {
         let u = Uniform::new_inclusive(u16::MIN, u16::MAX).expect("u16::MIN <= u16::MAX");
         format!(
             "{:X}:{:X}:{:X}:{:X}:{:X}:{:X}:{:X}:{:X}",
@@ -123,26 +123,26 @@ impl<L: Data> Dummy<IPv6<L>> for String {
 
 impl<L: Data> Dummy<IPv6<L>> for Ipv6Addr {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &IPv6<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &IPv6<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng::<Ipv6Addr, _>(rng)
     }
 }
 
 impl<L: Data + Copy> Dummy<IP<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &IP<L>, _rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &IP<L>, _rng: &mut R) -> Self {
         IPv4(c.0).fake()
     }
 }
 
 impl<L: Data> Dummy<IP<L>> for IpAddr {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &IP<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &IP<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng::<IpAddr, _>(rng)
     }
 }
 
 impl<L: Data> Dummy<MACAddress<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &MACAddress<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &MACAddress<L>, rng: &mut R) -> Self {
         let u = Uniform::new_inclusive(u8::MIN, u8::MAX).expect("u8::MIN <= u8::MAX");
         format!(
             "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
@@ -157,14 +157,14 @@ impl<L: Data> Dummy<MACAddress<L>> for String {
 }
 
 impl<L: Data> Dummy<UserAgent<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &UserAgent<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &UserAgent<L>, rng: &mut R) -> Self {
         let s = *L::INTERNET_USER_AGENT.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<UserAgent<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &UserAgent<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &UserAgent<L>, rng: &mut R) -> Self {
         L::INTERNET_USER_AGENT.choose(rng).unwrap()
     }
 }

--- a/fake/src/faker/impls/job.rs
+++ b/fake/src/faker/impls/job.rs
@@ -2,49 +2,49 @@ use crate::faker::job::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 
 impl<L: Data> Dummy<Seniority<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Seniority<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Seniority<L>, rng: &mut R) -> Self {
         let s = *L::JOB_SENIORITY.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<Seniority<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Seniority<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Seniority<L>, rng: &mut R) -> Self {
         L::JOB_SENIORITY.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<Field<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Field<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Field<L>, rng: &mut R) -> Self {
         let s = *L::JOB_FIELD.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<Field<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Field<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Field<L>, rng: &mut R) -> Self {
         L::JOB_FIELD.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<Position<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Position<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Position<L>, rng: &mut R) -> Self {
         let s = *L::JOB_POSITION.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<Position<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Position<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Position<L>, rng: &mut R) -> Self {
         L::JOB_POSITION.choose(rng).unwrap()
     }
 }
 
 impl<L: Data + Copy> Dummy<Title<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Title<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Title<L>, rng: &mut R) -> Self {
         L::JOB_TITLE_TPL
             .replace("{Seniority}", Seniority(c.0).fake_with_rng::<&str, _>(rng))
             .replace("{Field}", Field(c.0).fake_with_rng::<&str, _>(rng))

--- a/fake/src/faker/impls/lorem.rs
+++ b/fake/src/faker/impls/lorem.rs
@@ -2,23 +2,23 @@ use crate::faker::lorem::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 
 impl<L: Data> Dummy<Word<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Word<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Word<L>, rng: &mut R) -> Self {
         let s = *L::LOREM_WORD.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<Word<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Word<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Word<L>, rng: &mut R) -> Self {
         L::LOREM_WORD.choose(rng).unwrap()
     }
 }
 
 impl<L: Data + Copy> Dummy<Words<L>> for Vec<String> {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Words<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Words<L>, rng: &mut R) -> Self {
         let len: usize = c.1.fake_with_rng(rng);
         let mut v: Vec<String> = Vec::with_capacity(len);
         let w = Word(c.0);
@@ -30,7 +30,7 @@ impl<L: Data + Copy> Dummy<Words<L>> for Vec<String> {
 }
 
 impl<L: Data + Copy> Dummy<Sentence<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Sentence<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Sentence<L>, rng: &mut R) -> Self {
         let len: usize = c.1.fake_with_rng(rng);
         let mut v: Vec<String> = Vec::with_capacity(len);
         let w = Word(c.0);
@@ -42,7 +42,7 @@ impl<L: Data + Copy> Dummy<Sentence<L>> for String {
 }
 
 impl<L: Data + Copy> Dummy<Sentences<L>> for Vec<String> {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Sentences<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Sentences<L>, rng: &mut R) -> Self {
         let len: usize = c.1.fake_with_rng(rng);
         let mut v: Vec<String> = Vec::with_capacity(len);
         let s = Sentence(c.0, 4..10);
@@ -54,7 +54,7 @@ impl<L: Data + Copy> Dummy<Sentences<L>> for Vec<String> {
 }
 
 impl<L: Data + Copy> Dummy<Paragraph<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Paragraph<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Paragraph<L>, rng: &mut R) -> Self {
         let len: usize = c.1.fake_with_rng(rng);
         let mut v: Vec<String> = Vec::with_capacity(len);
         let s = Sentence(c.0, 4..10);
@@ -66,7 +66,7 @@ impl<L: Data + Copy> Dummy<Paragraph<L>> for String {
 }
 
 impl<L: Data + Copy> Dummy<Paragraphs<L>> for Vec<String> {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Paragraphs<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Paragraphs<L>, rng: &mut R) -> Self {
         let len: usize = c.1.fake_with_rng(rng);
         let mut v: Vec<String> = Vec::with_capacity(len);
         let p = Paragraph(c.0, 4..7);

--- a/fake/src/faker/impls/markdown.rs
+++ b/fake/src/faker/impls/markdown.rs
@@ -3,24 +3,24 @@ use crate::faker::markdown::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 
 impl<L: Data + Copy> Dummy<ItalicWord<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &ItalicWord<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &ItalicWord<L>, rng: &mut R) -> Self {
         let s = *L::LOREM_WORD.choose(rng).unwrap();
         format!("*{s}*")
     }
 }
 
 impl<L: Data + Copy> Dummy<BoldWord<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &BoldWord<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &BoldWord<L>, rng: &mut R) -> Self {
         let s = *L::LOREM_WORD.choose(rng).unwrap();
         format!("**{s}**")
     }
 }
 
 impl<L: Data + Copy> Dummy<Link<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Link<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Link<L>, rng: &mut R) -> Self {
         let text: String = Word(c.0).fake_with_rng::<&str, _>(rng).to_string();
         let url: String = Word(c.0).fake_with_rng(rng);
         format!("[{text}](https://{url})")
@@ -28,7 +28,7 @@ impl<L: Data + Copy> Dummy<Link<L>> for String {
 }
 
 impl<L: Data + Copy> Dummy<BulletPoints<L>> for Vec<String> {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &BulletPoints<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &BulletPoints<L>, rng: &mut R) -> Self {
         let len: usize = c.1.fake_with_rng(rng);
         let mut v: Vec<String> = Vec::with_capacity(len);
         let w: Word<L> = Word(c.0);
@@ -40,7 +40,7 @@ impl<L: Data + Copy> Dummy<BulletPoints<L>> for Vec<String> {
 }
 
 impl<L: Data + Copy> Dummy<ListItems<L>> for Vec<String> {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &ListItems<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &ListItems<L>, rng: &mut R) -> Self {
         let len: usize = c.1.fake_with_rng(rng);
         let mut v: Vec<String> = Vec::with_capacity(len);
         let item: Word<L> = Word(c.0);
@@ -52,14 +52,14 @@ impl<L: Data + Copy> Dummy<ListItems<L>> for Vec<String> {
 }
 
 impl<L: Data + Copy> Dummy<BlockQuoteSingleLine<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &BlockQuoteSingleLine<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &BlockQuoteSingleLine<L>, rng: &mut R) -> Self {
         let sentence: String = Sentence(c.0, 4..10).fake_with_rng(rng);
         format!("> {sentence}")
     }
 }
 
 impl<L: Data + Copy> Dummy<BlockQuoteMultiLine<L>> for Vec<String> {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &BlockQuoteMultiLine<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &BlockQuoteMultiLine<L>, rng: &mut R) -> Self {
         let len: usize = c.1.fake_with_rng(rng);
         let mut v: Vec<String> = Vec::with_capacity(len);
         let sentence = Sentence(c.0, 4..10);
@@ -71,7 +71,7 @@ impl<L: Data + Copy> Dummy<BlockQuoteMultiLine<L>> for Vec<String> {
 }
 
 impl<L: Data + Copy> Dummy<Code<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Code<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Code<L>, rng: &mut R) -> Self {
         let code: String = Sentence(c.0, 4..10)
             .fake_with_rng::<String, _>(rng)
             .to_string();

--- a/fake/src/faker/impls/name.rs
+++ b/fake/src/faker/impls/name.rs
@@ -2,62 +2,62 @@ use crate::faker::name::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 
 impl<L: Data> Dummy<FirstName<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &FirstName<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &FirstName<L>, rng: &mut R) -> Self {
         let s = *L::NAME_FIRST_NAME.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<FirstName<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &FirstName<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &FirstName<L>, rng: &mut R) -> Self {
         L::NAME_FIRST_NAME.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<LastName<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &LastName<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &LastName<L>, rng: &mut R) -> Self {
         let s = *L::NAME_LAST_NAME.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<LastName<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &LastName<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &LastName<L>, rng: &mut R) -> Self {
         L::NAME_LAST_NAME.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<Title<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Title<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Title<L>, rng: &mut R) -> Self {
         let s = *L::NAME_TITLE.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<Title<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Title<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Title<L>, rng: &mut R) -> Self {
         L::NAME_TITLE.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<Suffix<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Suffix<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Suffix<L>, rng: &mut R) -> Self {
         let s = *L::NAME_SUFFIX.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<Suffix<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Suffix<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Suffix<L>, rng: &mut R) -> Self {
         L::NAME_SUFFIX.choose(rng).unwrap()
     }
 }
 
 impl<L: Data + Copy> Dummy<Name<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &Name<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &Name<L>, rng: &mut R) -> Self {
         L::NAME_TPL
             .replace("{FirstName}", FirstName(c.0).fake_with_rng::<&str, _>(rng))
             .replace("{LastName}", LastName(c.0).fake_with_rng::<&str, _>(rng))
@@ -65,7 +65,7 @@ impl<L: Data + Copy> Dummy<Name<L>> for String {
 }
 
 impl<L: Data + Copy> Dummy<NameWithTitle<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &NameWithTitle<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &NameWithTitle<L>, rng: &mut R) -> Self {
         L::NAME_WITH_TITLE_TPL
             .replace("{Title}", Title(c.0).fake_with_rng::<&str, _>(rng))
             .replace("{FirstName}", FirstName(c.0).fake_with_rng::<&str, _>(rng))

--- a/fake/src/faker/impls/number.rs
+++ b/fake/src/faker/impls/number.rs
@@ -3,23 +3,23 @@ use crate::faker::numerify_sym;
 use crate::locales::Data;
 use crate::Dummy;
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 
 impl<L: Data> Dummy<Digit<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Digit<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Digit<L>, rng: &mut R) -> Self {
         let s = *L::NUMBER_DIGIT.choose(rng).unwrap();
         s.into()
     }
 }
 
 impl<L: Data> Dummy<Digit<L>> for &str {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Digit<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Digit<L>, rng: &mut R) -> Self {
         L::NUMBER_DIGIT.choose(rng).unwrap()
     }
 }
 
 impl<L: Data> Dummy<NumberWithFormat<'_, L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &NumberWithFormat<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &NumberWithFormat<L>, rng: &mut R) -> Self {
         numerify_sym(c.1, rng)
     }
 }

--- a/fake/src/faker/impls/phone_number.rs
+++ b/fake/src/faker/impls/phone_number.rs
@@ -3,17 +3,17 @@ use crate::faker::phone_number::raw::*;
 use crate::locales::Data;
 use crate::Dummy;
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 
 impl<L: Data> Dummy<PhoneNumber<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &PhoneNumber<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &PhoneNumber<L>, rng: &mut R) -> Self {
         let fmt = L::PHONE_NUMBER_FORMATS.choose(rng).unwrap();
         numerify_sym(fmt, rng)
     }
 }
 
 impl<L: Data> Dummy<CellNumber<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_c: &CellNumber<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_c: &CellNumber<L>, rng: &mut R) -> Self {
         let fmt = L::PHONE_CELL_NUMBER_FORMATS.choose(rng).unwrap();
         numerify_sym(fmt, rng)
     }

--- a/fake/src/faker/impls/picsum.rs
+++ b/fake/src/faker/impls/picsum.rs
@@ -2,10 +2,10 @@ use crate::faker::picsum::raw::*;
 use crate::locales::Data;
 use crate::Dummy;
 use rand::distr::{Distribution, Uniform};
-use rand::Rng;
+use rand::RngExt;
 
 impl<L: Data> Dummy<Image<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Image<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Image<L>, rng: &mut R) -> Self {
         let width: u16 = Uniform::new_inclusive(100, 800)
             .expect("valid range")
             .sample(rng);
@@ -17,7 +17,7 @@ impl<L: Data> Dummy<Image<L>> for String {
 }
 
 impl<L: Data> Dummy<ImageWithSeed<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_c: &ImageWithSeed<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_c: &ImageWithSeed<L>, rng: &mut R) -> Self {
         let width: u16 = Uniform::new_inclusive(100, 800)
             .expect("valid range")
             .sample(rng);
@@ -30,7 +30,7 @@ impl<L: Data> Dummy<ImageWithSeed<L>> for String {
 }
 
 impl<L: Data> Dummy<ImageGrayscale<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &ImageGrayscale<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &ImageGrayscale<L>, rng: &mut R) -> Self {
         let width: u16 = Uniform::new_inclusive(100, 800)
             .expect("valid range")
             .sample(rng);
@@ -42,7 +42,7 @@ impl<L: Data> Dummy<ImageGrayscale<L>> for String {
 }
 
 impl<L: Data> Dummy<ImageBlur<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &ImageBlur<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &ImageBlur<L>, rng: &mut R) -> Self {
         let width: u16 = Uniform::new_inclusive(100, 800)
             .expect("valid range")
             .sample(rng);
@@ -57,7 +57,7 @@ impl<L: Data> Dummy<ImageBlur<L>> for String {
 }
 
 impl<L: Data> Dummy<ImageCustom<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &ImageCustom<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &ImageCustom<L>, rng: &mut R) -> Self {
         let width: u16 = c.1.width.unwrap_or_else(|| {
             Uniform::new_inclusive(100, 800)
                 .expect("valid range")

--- a/fake/src/faker/impls/time.rs
+++ b/fake/src/faker/impls/time.rs
@@ -1,20 +1,20 @@
 use crate::faker::time::raw::*;
 use crate::locales::Data;
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 
 const MINUTES_MAX_BOUND: i64 = 1_000_000;
 
 impl<L: Data> Dummy<Time<L>> for time::Time {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Time<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Time<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng(rng)
     }
 }
 
 impl<L: Data> Dummy<Time<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Time<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Time<L>, rng: &mut R) -> Self {
         let time: time::Time = Faker.fake_with_rng(rng);
         time.format(&time::format_description::parse(L::TIME_DEFAULT_TIME_FORMAT).unwrap())
             .unwrap()
@@ -23,14 +23,14 @@ impl<L: Data> Dummy<Time<L>> for String {
 
 impl<L: Data> Dummy<Date<L>> for time::Date {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Date<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Date<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng(rng)
     }
 }
 
 impl<L: Data> Dummy<Date<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Date<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Date<L>, rng: &mut R) -> Self {
         let date: time::Date = Faker.fake_with_rng(rng);
         date.format(&time::format_description::parse(L::TIME_DEFAULT_DATE_FORMAT).unwrap())
             .unwrap()
@@ -39,21 +39,21 @@ impl<L: Data> Dummy<Date<L>> for String {
 
 impl<L: Data> Dummy<DateTime<L>> for time::PrimitiveDateTime {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng(rng)
     }
 }
 
 impl<L: Data> Dummy<DateTime<L>> for time::OffsetDateTime {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng(rng)
     }
 }
 
 impl<L: Data> Dummy<DateTime<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &DateTime<L>, rng: &mut R) -> Self {
         let datetime: time::OffsetDateTime = Faker.fake_with_rng(rng);
         datetime
             .format(&time::format_description::parse(L::TIME_DEFAULT_DATETIME_FORMAT).unwrap())
@@ -63,13 +63,13 @@ impl<L: Data> Dummy<DateTime<L>> for String {
 
 impl<L: Data> Dummy<Duration<L>> for time::Duration {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Duration<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Duration<L>, rng: &mut R) -> Self {
         Faker.fake_with_rng(rng)
     }
 }
 
 impl<L: Data> Dummy<DateTimeBefore<L>> for time::OffsetDateTime {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeBefore<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &DateTimeBefore<L>, rng: &mut R) -> Self {
         let mins: i64 = (1..MINUTES_MAX_BOUND).fake_with_rng(rng);
         let duration = time::Duration::minutes(mins);
         c.1 - duration
@@ -77,7 +77,7 @@ impl<L: Data> Dummy<DateTimeBefore<L>> for time::OffsetDateTime {
 }
 
 impl<L: Data> Dummy<DateTimeBefore<L>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeBefore<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &DateTimeBefore<L>, rng: &mut R) -> Self {
         let datetime: time::OffsetDateTime = c.fake_with_rng(rng);
         datetime
             .format(&time::format_description::parse(L::TIME_DEFAULT_DATETIME_FORMAT).unwrap())
@@ -86,7 +86,7 @@ impl<L: Data> Dummy<DateTimeBefore<L>> for String {
 }
 
 impl<L: Data> Dummy<DateTimeAfter<L>> for time::OffsetDateTime {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeAfter<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &DateTimeAfter<L>, rng: &mut R) -> Self {
         let mins: i64 = (1..MINUTES_MAX_BOUND).fake_with_rng(rng);
         let duration = time::Duration::minutes(mins);
         c.1 + duration
@@ -95,7 +95,7 @@ impl<L: Data> Dummy<DateTimeAfter<L>> for time::OffsetDateTime {
 
 impl<L: Data> Dummy<DateTimeAfter<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeAfter<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &DateTimeAfter<L>, rng: &mut R) -> Self {
         let datetime: time::OffsetDateTime = c.fake_with_rng(rng);
         datetime
             .format(&time::format_description::parse(L::TIME_DEFAULT_DATETIME_FORMAT).unwrap())
@@ -105,7 +105,7 @@ impl<L: Data> Dummy<DateTimeAfter<L>> for String {
 
 impl<L: Data> Dummy<DateTimeBetween<L>> for time::OffsetDateTime {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeBetween<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &DateTimeBetween<L>, rng: &mut R) -> Self {
         let diff = c.2 - c.1;
         let max_minutes = diff.whole_minutes();
 
@@ -117,7 +117,7 @@ impl<L: Data> Dummy<DateTimeBetween<L>> for time::OffsetDateTime {
 
 impl<L: Data> Dummy<DateTimeBetween<L>> for String {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &DateTimeBetween<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &DateTimeBetween<L>, rng: &mut R) -> Self {
         let datetime: time::OffsetDateTime = c.fake_with_rng(rng);
         datetime
             .format(&time::format_description::parse(L::TIME_DEFAULT_DATETIME_FORMAT).unwrap())

--- a/fake/src/faker/mod.rs
+++ b/fake/src/faker/mod.rs
@@ -1,9 +1,9 @@
 use crate::Fake;
-use rand::Rng;
+use rand::RngExt;
 use std::char;
 
 #[inline]
-fn numerify_sym<R: Rng + ?Sized>(string: &str, rng: &mut R) -> String {
+fn numerify_sym<R: RngExt + ?Sized>(string: &str, rng: &mut R) -> String {
     string
         .chars()
         .map(|x| match x {

--- a/fake/src/impls/base64/mod.rs
+++ b/fake/src/impls/base64/mod.rs
@@ -12,7 +12,7 @@ pub struct Base64;
 pub struct UrlSafeBase64;
 
 impl Dummy<Base64> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Base64, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &Base64, rng: &mut R) -> Self {
         let data: Vec<u8> = Faker.fake_with_rng(rng);
         let padding = Faker.fake_with_rng(rng);
         let encoded = if padding {
@@ -25,7 +25,7 @@ impl Dummy<Base64> for String {
 }
 
 impl Dummy<UrlSafeBase64> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &UrlSafeBase64, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &UrlSafeBase64, rng: &mut R) -> Self {
         let data: Vec<u8> = Faker.fake_with_rng(rng);
         let padding = Faker.fake_with_rng(rng);
         let encoded = if padding {
@@ -38,14 +38,14 @@ impl Dummy<UrlSafeBase64> for String {
 }
 
 impl Dummy<Faker> for Base64Value {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_config: &Faker, rng: &mut R) -> Self {
         let s = String::dummy_with_rng(&Base64, rng);
         Base64Value(s)
     }
 }
 
 impl Dummy<Faker> for UrlSafeBase64Value {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_config: &Faker, rng: &mut R) -> Self {
         let s = String::dummy_with_rng(&UrlSafeBase64, rng);
         UrlSafeBase64Value(s)
     }

--- a/fake/src/impls/bigdecimal/mod.rs
+++ b/fake/src/impls/bigdecimal/mod.rs
@@ -1,13 +1,13 @@
 use crate::{Dummy, Fake, Faker};
 use bigdecimal_rs::num_bigint::{BigInt, Sign};
-use rand::Rng;
+use rand::RngExt;
 
 pub struct BigDecimal;
 pub struct NegativeBigDecimal;
 pub struct PositiveBigDecimal;
 pub struct NoBigDecimalPoints;
 
-fn create_big_decimal<R: Rng + ?Sized>(rng: &mut R, sign: Sign) -> bigdecimal_rs::BigDecimal {
+fn create_big_decimal<R: RngExt + ?Sized>(rng: &mut R, sign: Sign) -> bigdecimal_rs::BigDecimal {
     let parts: [u32; 4] = Faker.fake_with_rng(rng);
     let int = BigInt::from_slice(sign, &parts);
     let scale = (0..64).fake_with_rng(rng);
@@ -16,7 +16,7 @@ fn create_big_decimal<R: Rng + ?Sized>(rng: &mut R, sign: Sign) -> bigdecimal_rs
 }
 
 impl Dummy<Faker> for bigdecimal_rs::BigDecimal {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let sign = if Faker.fake_with_rng(rng) {
             Sign::Plus
         } else {
@@ -28,25 +28,25 @@ impl Dummy<Faker> for bigdecimal_rs::BigDecimal {
 }
 
 impl Dummy<BigDecimal> for bigdecimal_rs::BigDecimal {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &BigDecimal, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &BigDecimal, rng: &mut R) -> Self {
         Faker.fake_with_rng(rng)
     }
 }
 
 impl Dummy<NegativeBigDecimal> for bigdecimal_rs::BigDecimal {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &NegativeBigDecimal, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &NegativeBigDecimal, rng: &mut R) -> Self {
         create_big_decimal(rng, Sign::Minus)
     }
 }
 
 impl Dummy<PositiveBigDecimal> for bigdecimal_rs::BigDecimal {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &PositiveBigDecimal, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &PositiveBigDecimal, rng: &mut R) -> Self {
         create_big_decimal(rng, Sign::Plus)
     }
 }
 
 impl Dummy<NoBigDecimalPoints> for bigdecimal_rs::BigDecimal {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &NoBigDecimalPoints, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &NoBigDecimalPoints, rng: &mut R) -> Self {
         let decimal: bigdecimal_rs::BigDecimal = Faker.fake_with_rng(rng);
         decimal.with_scale(0)
     }

--- a/fake/src/impls/bson_oid/mod.rs
+++ b/fake/src/impls/bson_oid/mod.rs
@@ -5,7 +5,7 @@ use bson::oid::ObjectId;
 use crate::{Dummy, Faker};
 
 impl Dummy<Faker> for ObjectId {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let mut bytes = [0u8; 12];
         rng.fill(&mut bytes);
         ObjectId::from_bytes(bytes)

--- a/fake/src/impls/chrono/mod.rs
+++ b/fake/src/impls/chrono/mod.rs
@@ -4,7 +4,7 @@ use crate::{Dummy, Fake, Faker};
 use chrono::{
     Date, DateTime, Duration, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc,
 };
-use rand::Rng;
+use rand::RngExt;
 
 const YEAR_MAG: i32 = 3_000i32;
 
@@ -19,19 +19,19 @@ fn is_leap(year: i32) -> bool {
 }
 
 impl Dummy<Faker> for Duration {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         Duration::nanoseconds(Faker.fake_with_rng(rng))
     }
 }
 
 impl Dummy<Faker> for Utc {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, _: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, _: &mut R) -> Self {
         Utc
     }
 }
 
 impl Dummy<Faker> for FixedOffset {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         if rng.random_bool(0.5) {
             let halves: i32 = (0..=28).fake_with_rng(rng);
             FixedOffset::east_opt(halves * 30 * 60).expect("failed to create FixedOffset")
@@ -46,7 +46,7 @@ impl<Tz> Dummy<Faker> for DateTime<Tz>
 where
     Tz: TimeZone + Dummy<Faker>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let utc: DateTime<Utc> = Utc.timestamp_nanos(Faker.fake_with_rng(rng));
         let tz: Tz = Faker.fake_with_rng(rng);
         utc.with_timezone(&tz)
@@ -54,7 +54,7 @@ where
 }
 
 impl Dummy<Faker> for Date<Utc> {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let year: i32 = (1..YEAR_MAG).fake_with_rng(rng);
         let end = if is_leap(year) { 366 } else { 365 };
         let day_ord: u32 = (1..end).fake_with_rng(rng);
@@ -63,7 +63,7 @@ impl Dummy<Faker> for Date<Utc> {
 }
 
 impl Dummy<Faker> for NaiveTime {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let hour = (0..24).fake_with_rng(rng);
         let min = (0..60).fake_with_rng(rng);
         let sec = (0..60).fake_with_rng(rng);
@@ -72,7 +72,7 @@ impl Dummy<Faker> for NaiveTime {
 }
 
 impl Dummy<Faker> for NaiveDate {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let year: i32 = (1..YEAR_MAG).fake_with_rng(rng);
         let end = if is_leap(year) { 366 } else { 365 };
         let day_ord: u32 = (1..end).fake_with_rng(rng);
@@ -81,7 +81,7 @@ impl Dummy<Faker> for NaiveDate {
 }
 
 impl Dummy<Faker> for NaiveDateTime {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let date = Faker.fake_with_rng(rng);
         let time = Faker.fake_with_rng(rng);
         NaiveDateTime::new(date, time)
@@ -114,7 +114,7 @@ impl<const N: usize> Dummy<Precision<N>> for NaiveTime
 where
     Precision<N>: AllowedPrecision,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Precision<N>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Precision<N>, rng: &mut R) -> Self {
         let hour = (0..24).fake_with_rng(rng);
         let min = (0..60).fake_with_rng(rng);
         let sec = (0..60).fake_with_rng(rng);
@@ -128,7 +128,7 @@ impl<const N: usize> Dummy<Precision<N>> for NaiveDateTime
 where
     Precision<N>: AllowedPrecision,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(precision: &Precision<N>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(precision: &Precision<N>, rng: &mut R) -> Self {
         let date = Faker.fake_with_rng(rng);
         let time = Precision::<N>::fake_with_rng(precision, rng);
         NaiveDateTime::new(date, time)
@@ -140,7 +140,7 @@ where
     Tz: TimeZone + Dummy<Faker>,
     Precision<N>: AllowedPrecision,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Precision<N>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Precision<N>, rng: &mut R) -> Self {
         let nanos: i64 = Faker.fake_with_rng(rng);
         let utc: DateTime<Utc> = Utc.timestamp_nanos(Precision::<N>::to_scale(nanos));
         let tz: Tz = Faker.fake_with_rng(rng);

--- a/fake/src/impls/chrono_tz/mod.rs
+++ b/fake/src/impls/chrono_tz/mod.rs
@@ -1,9 +1,9 @@
 use crate::{Dummy, Fake, Faker};
 use chrono_tz::{Tz, TZ_VARIANTS};
-use rand::Rng;
+use rand::RngExt;
 
 impl Dummy<Faker> for Tz {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let index: usize = (0..TZ_VARIANTS.len()).fake_with_rng(rng);
         TZ_VARIANTS[index]
     }

--- a/fake/src/impls/color/mod.rs
+++ b/fake/src/impls/color/mod.rs
@@ -1,10 +1,10 @@
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 
 use random_color::{options::Luminosity, RandomColor};
 
 impl Dummy<Faker> for RandomColor {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let mut c = RandomColor::new();
         c.seed(Faker.fake_with_rng::<u64, _>(rng))
             .alpha(Faker.fake_with_rng::<f32, _>(rng))

--- a/fake/src/impls/decimal/mod.rs
+++ b/fake/src/impls/decimal/mod.rs
@@ -1,5 +1,5 @@
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 
 pub struct Decimal;
 pub struct NegativeDecimal;
@@ -7,7 +7,7 @@ pub struct PositiveDecimal;
 pub struct NoDecimalPoints;
 
 impl Dummy<Faker> for rust_decimal::Decimal {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         rust_decimal::Decimal::from_parts(
             Faker.fake_with_rng(rng),
             Faker.fake_with_rng(rng),
@@ -19,13 +19,13 @@ impl Dummy<Faker> for rust_decimal::Decimal {
 }
 
 impl Dummy<Decimal> for rust_decimal::Decimal {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Decimal, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Decimal, rng: &mut R) -> Self {
         Faker.fake_with_rng(rng)
     }
 }
 
 impl Dummy<NegativeDecimal> for rust_decimal::Decimal {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &NegativeDecimal, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &NegativeDecimal, rng: &mut R) -> Self {
         rust_decimal::Decimal::from_parts(
             Faker.fake_with_rng(rng),
             Faker.fake_with_rng(rng),
@@ -37,7 +37,7 @@ impl Dummy<NegativeDecimal> for rust_decimal::Decimal {
 }
 
 impl Dummy<PositiveDecimal> for rust_decimal::Decimal {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &PositiveDecimal, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &PositiveDecimal, rng: &mut R) -> Self {
         rust_decimal::Decimal::from_parts(
             Faker.fake_with_rng(rng),
             Faker.fake_with_rng(rng),
@@ -49,7 +49,7 @@ impl Dummy<PositiveDecimal> for rust_decimal::Decimal {
 }
 
 impl Dummy<NoDecimalPoints> for rust_decimal::Decimal {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &NoDecimalPoints, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &NoDecimalPoints, rng: &mut R) -> Self {
         let mut decimal: rust_decimal::Decimal = Faker.fake_with_rng(rng);
         decimal.set_scale(0).expect("failed to set scale");
         decimal

--- a/fake/src/impls/either/mod.rs
+++ b/fake/src/impls/either/mod.rs
@@ -6,7 +6,7 @@ where
     A: Dummy<Faker>,
     B: Dummy<Faker>,
 {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(faker: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(faker: &Faker, rng: &mut R) -> Self {
         if Faker.fake_with_rng(rng) {
             Either::Left(faker.fake_with_rng(rng))
         } else {

--- a/fake/src/impls/email_address/mod.rs
+++ b/fake/src/impls/email_address/mod.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use email_address::EmailAddress;
-use rand::Rng;
+use rand::RngExt;
 
 use crate::{
     faker::internet::raw::{FreeEmail, SafeEmail},
@@ -10,13 +10,13 @@ use crate::{
 };
 
 impl<L: Data + Copy> Dummy<FreeEmail<L>> for EmailAddress {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &FreeEmail<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &FreeEmail<L>, rng: &mut R) -> Self {
         Self::from_str(&<String as Dummy<FreeEmail<L>>>::dummy_with_rng(c, rng)).unwrap()
     }
 }
 
 impl<L: Data + Copy> Dummy<SafeEmail<L>> for EmailAddress {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &SafeEmail<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &SafeEmail<L>, rng: &mut R) -> Self {
         Self::from_str(&<String as Dummy<SafeEmail<L>>>::dummy_with_rng(c, rng)).unwrap()
     }
 }

--- a/fake/src/impls/ferroid/mod.rs
+++ b/fake/src/impls/ferroid/mod.rs
@@ -15,28 +15,28 @@ pub struct FerroidInstagramId;
 
 // --- ULID ---
 impl Dummy<Faker> for ULID {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let time_part: u128 = rng.random_range(0..(1 << ULID::TIMESTAMP_BITS));
         let rand_part: u128 = rng.random_range(0..(1 << ULID::RANDOM_BITS));
         ULID::from_components(time_part, rand_part)
     }
 }
 impl Dummy<FerroidULID> for ULID {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &FerroidULID, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &FerroidULID, rng: &mut R) -> Self {
         let time_part: u128 = rng.random_range(0..(1 << ULID::TIMESTAMP_BITS));
         let rand_part: u128 = rng.random_range(0..(1 << ULID::RANDOM_BITS));
         ULID::from_components(time_part, rand_part)
     }
 }
 impl Dummy<FerroidULID> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &FerroidULID, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &FerroidULID, rng: &mut R) -> Self {
         ULID::dummy_with_rng(config, rng).encode().to_string()
     }
 }
 
 // --- SnowflakeTwitterId ---
 impl Dummy<Faker> for SnowflakeTwitterId {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let timestamp: u64 = rng.random_range(0..(1 << SnowflakeTwitterId::TIMESTAMP_BITS));
         let machine_id: u64 = rng.random_range(0..(1 << SnowflakeTwitterId::MACHINE_ID_BITS));
         let sequence: u64 = rng.random_range(0..(1 << SnowflakeTwitterId::SEQUENCE_BITS));
@@ -44,7 +44,7 @@ impl Dummy<Faker> for SnowflakeTwitterId {
     }
 }
 impl Dummy<FerroidTwitterId> for SnowflakeTwitterId {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &FerroidTwitterId, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &FerroidTwitterId, rng: &mut R) -> Self {
         let timestamp: u64 = rng.random_range(0..(1 << SnowflakeTwitterId::TIMESTAMP_BITS));
         let machine_id: u64 = rng.random_range(0..(1 << SnowflakeTwitterId::MACHINE_ID_BITS));
         let sequence: u64 = rng.random_range(0..(1 << SnowflakeTwitterId::SEQUENCE_BITS));
@@ -52,7 +52,7 @@ impl Dummy<FerroidTwitterId> for SnowflakeTwitterId {
     }
 }
 impl Dummy<FerroidTwitterId> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &FerroidTwitterId, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &FerroidTwitterId, rng: &mut R) -> Self {
         SnowflakeTwitterId::dummy_with_rng(config, rng)
             .encode()
             .to_string()
@@ -61,7 +61,7 @@ impl Dummy<FerroidTwitterId> for String {
 
 // --- SnowflakeDiscordId ---
 impl Dummy<Faker> for SnowflakeDiscordId {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let timestamp: u64 = rng.random_range(0..(1 << SnowflakeDiscordId::TIMESTAMP_BITS));
         let machine_id: u64 = rng.random_range(0..(1 << SnowflakeDiscordId::MACHINE_ID_BITS));
         let sequence: u64 = rng.random_range(0..(1 << SnowflakeDiscordId::SEQUENCE_BITS));
@@ -69,7 +69,7 @@ impl Dummy<Faker> for SnowflakeDiscordId {
     }
 }
 impl Dummy<FerroidDiscordId> for SnowflakeDiscordId {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &FerroidDiscordId, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &FerroidDiscordId, rng: &mut R) -> Self {
         let timestamp: u64 = rng.random_range(0..(1 << SnowflakeDiscordId::TIMESTAMP_BITS));
         let machine_id: u64 = rng.random_range(0..(1 << SnowflakeDiscordId::MACHINE_ID_BITS));
         let sequence: u64 = rng.random_range(0..(1 << SnowflakeDiscordId::SEQUENCE_BITS));
@@ -77,7 +77,7 @@ impl Dummy<FerroidDiscordId> for SnowflakeDiscordId {
     }
 }
 impl Dummy<FerroidDiscordId> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &FerroidDiscordId, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &FerroidDiscordId, rng: &mut R) -> Self {
         SnowflakeDiscordId::dummy_with_rng(config, rng)
             .encode()
             .to_string()
@@ -86,7 +86,7 @@ impl Dummy<FerroidDiscordId> for String {
 
 // --- SnowflakeMastodonId ---
 impl Dummy<Faker> for SnowflakeMastodonId {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let timestamp: u64 = rng.random_range(0..(1 << SnowflakeMastodonId::TIMESTAMP_BITS));
         let machine_id: u64 = rng.random_range(0..(1 << SnowflakeMastodonId::MACHINE_ID_BITS));
         let sequence: u64 = rng.random_range(0..(1 << SnowflakeMastodonId::SEQUENCE_BITS));
@@ -94,7 +94,7 @@ impl Dummy<Faker> for SnowflakeMastodonId {
     }
 }
 impl Dummy<FerroidMastodonId> for SnowflakeMastodonId {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &FerroidMastodonId, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &FerroidMastodonId, rng: &mut R) -> Self {
         let timestamp: u64 = rng.random_range(0..(1 << SnowflakeMastodonId::TIMESTAMP_BITS));
         let machine_id: u64 = rng.random_range(0..(1 << SnowflakeMastodonId::MACHINE_ID_BITS));
         let sequence: u64 = rng.random_range(0..(1 << SnowflakeMastodonId::SEQUENCE_BITS));
@@ -102,7 +102,7 @@ impl Dummy<FerroidMastodonId> for SnowflakeMastodonId {
     }
 }
 impl Dummy<FerroidMastodonId> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &FerroidMastodonId, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &FerroidMastodonId, rng: &mut R) -> Self {
         SnowflakeMastodonId::dummy_with_rng(config, rng)
             .encode()
             .to_string()
@@ -111,7 +111,7 @@ impl Dummy<FerroidMastodonId> for String {
 
 // --- SnowflakeInstagramId ---
 impl Dummy<Faker> for SnowflakeInstagramId {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let timestamp: u64 = rng.random_range(0..(1 << SnowflakeInstagramId::TIMESTAMP_BITS));
         let machine_id: u64 = rng.random_range(0..(1 << SnowflakeInstagramId::MACHINE_ID_BITS));
         let sequence: u64 = rng.random_range(0..(1 << SnowflakeInstagramId::SEQUENCE_BITS));
@@ -119,7 +119,7 @@ impl Dummy<Faker> for SnowflakeInstagramId {
     }
 }
 impl Dummy<FerroidInstagramId> for SnowflakeInstagramId {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &FerroidInstagramId, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &FerroidInstagramId, rng: &mut R) -> Self {
         let timestamp: u64 = rng.random_range(0..(1 << SnowflakeInstagramId::TIMESTAMP_BITS));
         let machine_id: u64 = rng.random_range(0..(1 << SnowflakeInstagramId::MACHINE_ID_BITS));
         let sequence: u64 = rng.random_range(0..(1 << SnowflakeInstagramId::SEQUENCE_BITS));
@@ -127,7 +127,7 @@ impl Dummy<FerroidInstagramId> for SnowflakeInstagramId {
     }
 }
 impl Dummy<FerroidInstagramId> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &FerroidInstagramId, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &FerroidInstagramId, rng: &mut R) -> Self {
         SnowflakeInstagramId::dummy_with_rng(config, rng)
             .encode()
             .to_string()

--- a/fake/src/impls/geo/mod.rs
+++ b/fake/src/impls/geo/mod.rs
@@ -1,12 +1,12 @@
 use std::ops::Range;
 
 use geo_types::CoordNum;
-use rand::Rng;
+use rand::RngExt;
 
 use crate::{Dummy, Fake, Faker};
 
 impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Coord<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         geo_types::Coord::<T> {
             x: Faker.fake_with_rng(rng),
             y: Faker.fake_with_rng(rng),
@@ -15,7 +15,7 @@ impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Coord<T> {
 }
 
 impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Line<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         geo_types::Line::<T> {
             start: Faker.fake_with_rng(rng),
             end: Faker.fake_with_rng(rng),
@@ -24,44 +24,44 @@ impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Line<T> {
 }
 
 impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::LineString<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         geo_types::LineString::<T>::new(Faker.fake_with_rng(rng))
     }
 }
 
 impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::MultiLineString<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         geo_types::MultiLineString::<T>::new(Faker.fake_with_rng(rng))
     }
 }
 
 impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Point<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         geo_types::Point::<T>::new(Faker.fake_with_rng(rng), Faker.fake_with_rng(rng))
     }
 }
 
 impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::MultiPoint<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         geo_types::MultiPoint::<T>::new(Faker.fake_with_rng(rng))
     }
 }
 
 impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Polygon<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         // Polygon will auto-close these LineString.
         geo_types::Polygon::<T>::new(Faker.fake_with_rng(rng), Faker.fake_with_rng(rng))
     }
 }
 
 impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::MultiPolygon<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         geo_types::MultiPolygon::<T>::new(Faker.fake_with_rng(rng))
     }
 }
 
 impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Rect<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         // Rect points can not overlap.
         let nums: Vec<T> = crate::unique::<T, _>(rng, 4);
         let coord_1 = geo_types::Coord::<T> {
@@ -77,8 +77,8 @@ impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Rect<T> {
 }
 
 impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Triangle<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-        fn step<T, R: Rng + ?Sized>(start: T, steps: usize, rng: &mut R) -> T
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        fn step<T, R: RngExt + ?Sized>(start: T, steps: usize, rng: &mut R) -> T
         where
             T: CoordNum,
         {
@@ -120,7 +120,7 @@ const GEOMETRY_UNION_MEMBERS: Range<usize> = 0..9;
 struct NonRecursiveGeometry<T: CoordNum = f64>(geo_types::Geometry<T>);
 
 impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for NonRecursiveGeometry<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let union_index: usize = GEOMETRY_UNION_MEMBERS.fake_with_rng(rng);
         match union_index {
             0 => NonRecursiveGeometry(geo_types::geometry::Geometry::Point::<T>(
@@ -160,7 +160,7 @@ impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for NonRecursiveGeometry<T> {
 }
 
 impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Geometry<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let union_index: usize = GEOMETRY_UNION_MEMBERS.fake_with_rng(rng);
         match union_index {
             0 => geo_types::geometry::Geometry::Point::<T>(Faker.fake_with_rng(rng)),
@@ -179,7 +179,7 @@ impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::Geometry<T> {
 }
 
 impl<T: CoordNum + Dummy<Faker>> Dummy<Faker> for geo_types::GeometryCollection<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         geo_types::GeometryCollection::<T>::new_from(
             Faker
                 .fake_with_rng::<Vec<NonRecursiveGeometry<T>>, _>(rng)

--- a/fake/src/impls/glam/mod.rs
+++ b/fake/src/impls/glam/mod.rs
@@ -2,7 +2,7 @@ use crate::{Dummy, Fake, Faker};
 use glam::{Mat3, Mat4, Vec2, Vec3, Vec4};
 
 impl Dummy<Faker> for Mat3 {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_f: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_f: &Faker, rng: &mut R) -> Self {
         let col_1: Vec3 = Faker.fake_with_rng(rng);
         let col_2: Vec3 = Faker.fake_with_rng(rng);
         let col_3: Vec3 = Faker.fake_with_rng(rng);
@@ -11,7 +11,7 @@ impl Dummy<Faker> for Mat3 {
 }
 
 impl Dummy<Faker> for Mat4 {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_f: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_f: &Faker, rng: &mut R) -> Self {
         let col_1: Vec4 = Faker.fake_with_rng(rng);
         let col_2: Vec4 = Faker.fake_with_rng(rng);
         let col_3: Vec4 = Faker.fake_with_rng(rng);
@@ -21,7 +21,7 @@ impl Dummy<Faker> for Mat4 {
 }
 
 impl Dummy<Faker> for Vec3 {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_f: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_f: &Faker, rng: &mut R) -> Self {
         let x: f32 = Faker.fake_with_rng(rng);
         let y: f32 = Faker.fake_with_rng(rng);
         let z: f32 = Faker.fake_with_rng(rng);
@@ -30,7 +30,7 @@ impl Dummy<Faker> for Vec3 {
 }
 
 impl Dummy<Faker> for Vec2 {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_f: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_f: &Faker, rng: &mut R) -> Self {
         let x: f32 = Faker.fake_with_rng(rng);
         let y: f32 = Faker.fake_with_rng(rng);
         Vec2::new(x, y)
@@ -38,7 +38,7 @@ impl Dummy<Faker> for Vec2 {
 }
 
 impl Dummy<Faker> for Vec4 {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_f: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_f: &Faker, rng: &mut R) -> Self {
         let x: f32 = Faker.fake_with_rng(rng);
         let y: f32 = Faker.fake_with_rng(rng);
         let z: f32 = Faker.fake_with_rng(rng);
@@ -51,7 +51,7 @@ mod tests {
     use super::*;
     use glam::{vec2, vec3, vec4};
     use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::{RngExt, SeedableRng};
 
     const SEED: [u8; 32] = [
         1, 0, 0, 0, 23, 0, 0, 0, 200, 1, 0, 0, 210, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/fake/src/impls/http/mod.rs
+++ b/fake/src/impls/http/mod.rs
@@ -1,7 +1,7 @@
 use crate::{Dummy, Fake, Faker};
 use http::uri;
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 use std::mem;
 use std::net::Ipv4Addr;
 use std::str::FromStr;
@@ -21,7 +21,7 @@ const VALID_SCHEME_CHARACTERS: &[char] = &[
 ];
 
 impl Dummy<Faker> for http::Method {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let i: u8 = (0..9).fake_with_rng(rng);
         match i {
             0 => http::Method::GET,
@@ -38,21 +38,21 @@ impl Dummy<Faker> for http::Method {
 }
 
 impl Dummy<Faker> for http::HeaderValue {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let val = config.fake_with_rng::<String, _>(rng);
         http::HeaderValue::try_from(val).unwrap()
     }
 }
 
 impl Dummy<Faker> for http::HeaderName {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let val = config.fake_with_rng::<String, _>(rng);
         http::HeaderName::try_from(val).unwrap()
     }
 }
 
 impl<T: Dummy<Faker>> Dummy<Faker> for http::HeaderMap<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let len = rng.random_range(1..10);
         let mut map = http::HeaderMap::with_capacity(len);
         for _ in 0..len {
@@ -70,28 +70,28 @@ impl<T: Dummy<Faker>> Dummy<Faker> for http::HeaderMap<T> {
 }
 
 impl Dummy<Faker> for http::StatusCode {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let code = RFC_STATUS_CODES.choose(rng).unwrap();
         http::StatusCode::from_u16(*code).unwrap()
     }
 }
 
 impl Dummy<&[u16]> for Result<http::StatusCode, http::status::InvalidStatusCode> {
-    fn dummy_with_rng<R: Rng + ?Sized>(codes: &&[u16], rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(codes: &&[u16], rng: &mut R) -> Self {
         let code = codes.choose(rng).expect("no codes provided");
         http::StatusCode::from_u16(*code)
     }
 }
 
 impl Dummy<&[u16]> for http::StatusCode {
-    fn dummy_with_rng<R: Rng + ?Sized>(codes: &&[u16], rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(codes: &&[u16], rng: &mut R) -> Self {
         let code = codes.choose(rng).expect("no codes provided");
         http::StatusCode::from_u16(*code).expect("invalid status code")
     }
 }
 
 impl Dummy<Faker> for http::Version {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let i: u8 = (0..4).fake_with_rng(rng);
         match i {
             0 => http::Version::HTTP_2,
@@ -103,7 +103,7 @@ impl Dummy<Faker> for http::Version {
 }
 
 impl Dummy<Faker> for http::uri::Authority {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let mut authority = String::new();
 
         if rng.random_bool(0.5) {
@@ -157,7 +157,7 @@ impl Dummy<Faker> for http::uri::Authority {
 }
 
 impl Dummy<Faker> for http::uri::Scheme {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         // Some common schemes or a random valid scheme
         let scheme = match (0..7).fake_with_rng(rng) {
             0 => "http".to_string(),
@@ -187,7 +187,7 @@ impl Dummy<Faker> for http::uri::Scheme {
 }
 
 impl Dummy<Faker> for http::uri::PathAndQuery {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let mut path = format!(
             "/{}",
             url_escape::encode_path(&config.fake_with_rng::<String, _>(rng))
@@ -211,7 +211,7 @@ impl Dummy<Faker> for http::uri::PathAndQuery {
 }
 
 impl Dummy<Faker> for http::Uri {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let scheme = config.fake_with_rng::<uri::Scheme, _>(rng);
         let authority = config.fake_with_rng::<uri::Authority, _>(rng);
         let path = config.fake_with_rng::<uri::PathAndQuery, _>(rng);
@@ -226,7 +226,7 @@ impl Dummy<Faker> for http::Uri {
 }
 
 impl<T: Dummy<Faker>> Dummy<Faker> for http::Request<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let method: http::Method = config.fake_with_rng(rng);
         let uri: http::Uri = config.fake_with_rng(rng);
         let mut req = http::Request::builder()
@@ -240,7 +240,7 @@ impl<T: Dummy<Faker>> Dummy<Faker> for http::Request<T> {
 }
 
 impl<T: Dummy<Faker>> Dummy<Faker> for http::Response<T> {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let status: http::StatusCode = config.fake_with_rng(rng);
         let mut res = http::Response::builder()
             .status(status)

--- a/fake/src/impls/indexmap/mod.rs
+++ b/fake/src/impls/indexmap/mod.rs
@@ -1,6 +1,6 @@
 use crate::{Dummy, Fake, Faker};
 use indexmap::{IndexMap, IndexSet};
-use rand::Rng;
+use rand::RngExt;
 use std::hash::{BuildHasher, Hash};
 
 use super::std::collections::get_len;
@@ -11,7 +11,7 @@ where
     V: Dummy<Faker>,
     S: BuildHasher + Default,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let len = get_len(config, rng);
         let mut m = IndexMap::with_capacity_and_hasher(len, S::default());
         for _ in 0..len {
@@ -26,7 +26,7 @@ where
     T: Dummy<Faker> + Hash + Eq,
     S: BuildHasher + Default,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let len = get_len(config, rng);
         let mut m = IndexSet::with_capacity_and_hasher(len, S::default());
         for _ in 0..len {

--- a/fake/src/impls/semver/mod.rs
+++ b/fake/src/impls/semver/mod.rs
@@ -2,12 +2,12 @@ use crate::faker::boolean::raw::Boolean;
 use crate::locales::EN;
 use crate::{Dummy, Fake, Faker};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 
 const UNSTABLE_SEMVER: &[&str] = &["alpha", "beta", "rc"];
 
 impl Dummy<Faker> for semver::Version {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let probability = 10;
         let pre = if Boolean(EN, probability).fake_with_rng(rng) {
             semver::Prerelease::new(&format!(

--- a/fake/src/impls/serde_json/mod.rs
+++ b/fake/src/impls/serde_json/mod.rs
@@ -13,7 +13,7 @@ const JSON_UNION_MEMBERS: Range<usize> = 0..6;
 struct NonRecursiveValue(Value);
 
 impl Dummy<Faker> for NonRecursiveValue {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let union_index: usize = JSON_UNION_MEMBERS_NON_RECURSIVE.fake_with_rng(rng);
         match union_index {
             0 => NonRecursiveValue(serde_json::Value::Null),
@@ -26,7 +26,7 @@ impl Dummy<Faker> for NonRecursiveValue {
 }
 
 impl Dummy<Faker> for Value {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let union_index: usize = JSON_UNION_MEMBERS.fake_with_rng(rng);
         match union_index {
             0 => serde_json::Value::Null,
@@ -41,7 +41,7 @@ impl Dummy<Faker> for Value {
 }
 
 impl Dummy<Faker> for Number {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         // Alternate between generating floats and integers
         if Faker.fake_with_rng::<bool, _>(rng) {
             Number::from_f64(config.fake_with_rng::<f64, _>(rng)).unwrap()
@@ -52,7 +52,7 @@ impl Dummy<Faker> for Number {
 }
 
 impl Dummy<Faker> for Map<String, Value> {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         Map::from_iter(
             config
                 .fake_with_rng::<HashMap<String, NonRecursiveValue>, _>(rng)

--- a/fake/src/impls/std/array.rs
+++ b/fake/src/impls/std/array.rs
@@ -1,11 +1,11 @@
 use crate::{Dummy, Fake};
-use rand::Rng;
+use rand::RngExt;
 
 impl<T, U, const N: usize> Dummy<U> for [T; N]
 where
     T: Dummy<U>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &U, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &U, rng: &mut R) -> Self {
         std::array::from_fn(|_| Fake::fake_with_rng::<T, _>(config, rng))
     }
 }

--- a/fake/src/impls/std/collections/binary_heap.rs
+++ b/fake/src/impls/std/collections/binary_heap.rs
@@ -1,12 +1,12 @@
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 use std::collections::BinaryHeap;
 
 impl<T> Dummy<Faker> for BinaryHeap<T>
 where
     T: Dummy<Faker> + Ord,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let len = super::get_len(config, rng);
         let mut v = BinaryHeap::with_capacity(len);
         for _ in 0..len {
@@ -21,7 +21,7 @@ where
     T: Dummy<E> + Ord,
     usize: Dummy<L>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &(E, L), rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &(E, L), rng: &mut R) -> Self {
         let len: usize = config.1.fake_with_rng(rng);
         let mut v = BinaryHeap::with_capacity(len);
         for _ in 0..len {

--- a/fake/src/impls/std/collections/btree_map.rs
+++ b/fake/src/impls/std/collections/btree_map.rs
@@ -1,5 +1,5 @@
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 use std::collections::BTreeMap;
 
 impl<K, V> Dummy<Faker> for BTreeMap<K, V>
@@ -7,7 +7,7 @@ where
     K: Dummy<Faker> + Ord,
     V: Dummy<Faker>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let len = super::get_len(config, rng);
         let mut m = BTreeMap::new();
         for _ in 0..len {

--- a/fake/src/impls/std/collections/btree_set.rs
+++ b/fake/src/impls/std/collections/btree_set.rs
@@ -1,12 +1,12 @@
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 use std::collections::BTreeSet;
 
 impl<T> Dummy<Faker> for BTreeSet<T>
 where
     T: Dummy<Faker> + Ord,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let len = super::get_len(config, rng);
         let mut m = BTreeSet::new();
         for _ in 0..len {

--- a/fake/src/impls/std/collections/hash_map.rs
+++ b/fake/src/impls/std/collections/hash_map.rs
@@ -1,5 +1,5 @@
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
 
@@ -9,7 +9,7 @@ where
     V: Dummy<Faker>,
     S: BuildHasher + Default,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let len = super::get_len(config, rng);
         let mut m = HashMap::with_capacity_and_hasher(len, S::default());
         for _ in 0..len {

--- a/fake/src/impls/std/collections/hash_set.rs
+++ b/fake/src/impls/std/collections/hash_set.rs
@@ -1,5 +1,5 @@
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 use std::collections::HashSet;
 use std::hash::{BuildHasher, Hash};
 
@@ -8,7 +8,7 @@ where
     T: Dummy<Faker> + Hash + Eq,
     S: BuildHasher + Default,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let len = super::get_len(config, rng);
         let mut m = HashSet::with_capacity_and_hasher(len, S::default());
         for _ in 0..len {

--- a/fake/src/impls/std/collections/linked_list.rs
+++ b/fake/src/impls/std/collections/linked_list.rs
@@ -1,12 +1,12 @@
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 use std::collections::LinkedList;
 
 impl<T> Dummy<Faker> for LinkedList<T>
 where
     T: Dummy<Faker>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let len = super::get_len(config, rng);
         let mut v = LinkedList::new();
         for _ in 0..len {
@@ -21,7 +21,7 @@ where
     T: Dummy<E>,
     usize: Dummy<L>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &(E, L), rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &(E, L), rng: &mut R) -> Self {
         let len: usize = config.1.fake_with_rng(rng);
         let mut v = LinkedList::new();
         for _ in 0..len {

--- a/fake/src/impls/std/collections/mod.rs
+++ b/fake/src/impls/std/collections/mod.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use rand::Rng;
+use rand::RngExt;
 
 use crate::{Fake, Faker};
 
@@ -16,7 +16,7 @@ pub mod vec;
 pub mod vec_deque;
 
 #[allow(unused_mut, unused_variables)]
-pub fn get_len<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> usize {
+pub fn get_len<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> usize {
     let mut range = DEFAULT_LEN_RANGE;
     #[cfg(feature = "maybe-non-empty-collections")]
     if config.fake_with_rng(rng) {

--- a/fake/src/impls/std/collections/vec.rs
+++ b/fake/src/impls/std/collections/vec.rs
@@ -1,11 +1,11 @@
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 
 impl<T> Dummy<Faker> for Vec<T>
 where
     T: Dummy<Faker>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let len = super::get_len(config, rng);
         let mut v = Vec::with_capacity(len);
         for _ in 0..len {
@@ -20,7 +20,7 @@ where
     T: Dummy<E>,
     usize: Dummy<L>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &(E, L), rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &(E, L), rng: &mut R) -> Self {
         let len: usize = config.1.fake_with_rng(rng);
         let mut v = Vec::with_capacity(len);
         for _ in 0..len {

--- a/fake/src/impls/std/collections/vec_deque.rs
+++ b/fake/src/impls/std/collections/vec_deque.rs
@@ -1,12 +1,12 @@
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 use std::collections::VecDeque;
 
 impl<T> Dummy<Faker> for VecDeque<T>
 where
     T: Dummy<Faker>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         let len = super::get_len(config, rng);
         let mut v = VecDeque::with_capacity(len);
         for _ in 0..len {
@@ -21,7 +21,7 @@ where
     T: Dummy<E>,
     usize: Dummy<L>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &(E, L), rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &(E, L), rng: &mut R) -> Self {
         let len: usize = config.1.fake_with_rng(rng);
         let mut v = VecDeque::with_capacity(len);
         for _ in 0..len {

--- a/fake/src/impls/std/container.rs
+++ b/fake/src/impls/std/container.rs
@@ -1,5 +1,5 @@
 use crate::Dummy;
-use rand::Rng;
+use rand::RngExt;
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::ops::Deref;
@@ -13,7 +13,7 @@ macro_rules! container_impl {
         where
             T: Dummy<U>,
         {
-            fn dummy_with_rng<R: Rng + ?Sized>(config: &U, rng: &mut R) -> Self {
+            fn dummy_with_rng<R: RngExt + ?Sized>(config: &U, rng: &mut R) -> Self {
                 $ptr::new(T::dummy_with_rng(config, rng))
             }
         }
@@ -33,7 +33,7 @@ where
     T: Dummy<U> + Deref,
     <T as Deref>::Target: Unpin,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &U, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &U, rng: &mut R) -> Self {
         Pin::new(T::dummy_with_rng(config, rng))
     }
 }
@@ -42,7 +42,7 @@ impl<T, U> Dummy<U> for Cow<'_, T>
 where
     T: Dummy<U> + Clone,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &U, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &U, rng: &mut R) -> Self {
         Cow::Owned(T::dummy_with_rng(config, rng))
     }
 }

--- a/fake/src/impls/std/net.rs
+++ b/fake/src/impls/std/net.rs
@@ -1,17 +1,17 @@
 use crate::{Dummy, Fake, Faker};
 use rand::distr::{Distribution, Uniform};
-use rand::Rng;
+use rand::RngExt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
 impl Dummy<Faker> for Ipv4Addr {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let u = Uniform::new_inclusive(u8::MIN, u8::MAX).expect("u8::MIN <= u8::MAX");
         Ipv4Addr::new(u.sample(rng), u.sample(rng), u.sample(rng), u.sample(rng))
     }
 }
 
 impl Dummy<Faker> for Ipv6Addr {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let u = Uniform::new_inclusive(u16::MIN, u16::MAX).expect("u16::MIN <= u16::MAX");
         Ipv6Addr::new(
             u.sample(rng),
@@ -27,7 +27,7 @@ impl Dummy<Faker> for Ipv6Addr {
 }
 
 impl Dummy<Faker> for IpAddr {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         if Faker.fake_with_rng::<bool, _>(rng) {
             IpAddr::V4(Faker.fake_with_rng::<Ipv4Addr, _>(rng))
         } else {
@@ -37,7 +37,7 @@ impl Dummy<Faker> for IpAddr {
 }
 
 impl Dummy<Faker> for SocketAddrV4 {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let ip: Ipv4Addr = Faker.fake_with_rng(rng);
         let port: u16 = Faker.fake_with_rng(rng);
         SocketAddrV4::new(ip, port)
@@ -45,7 +45,7 @@ impl Dummy<Faker> for SocketAddrV4 {
 }
 
 impl Dummy<Faker> for SocketAddrV6 {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let ip: Ipv6Addr = Faker.fake_with_rng(rng);
         let port: u16 = Faker.fake_with_rng(rng);
         let flowinfo: u32 = Faker.fake_with_rng(rng);

--- a/fake/src/impls/std/num.rs
+++ b/fake/src/impls/std/num.rs
@@ -1,6 +1,6 @@
 use crate::{Dummy, Faker};
 use rand::distr::{Distribution, Uniform};
-use rand::Rng;
+use rand::RngExt;
 use std::num::{
     NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
     NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
@@ -9,7 +9,7 @@ use std::num::{
 macro_rules! signed_faker_impl {
     ($nz_typ: ty, $typ:ty) => {
         impl Dummy<Faker> for $nz_typ {
-            fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+            fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
                 if rng.random_bool(0.5) {
                     let u = Uniform::new_inclusive(<$typ>::MIN, -1).expect("Can sample uniform");
                     <$nz_typ>::new(u.sample(rng)).unwrap()
@@ -25,7 +25,7 @@ macro_rules! signed_faker_impl {
 macro_rules! unsigned_faker_impl {
     ($nz_typ: ty, $typ:ty) => {
         impl Dummy<Faker> for $nz_typ {
-            fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+            fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
                 let u = Uniform::new_inclusive(1, <$typ>::MAX).expect("Can sample uniform");
                 <$nz_typ>::new(u.sample(rng)).unwrap()
             }

--- a/fake/src/impls/std/option.rs
+++ b/fake/src/impls/std/option.rs
@@ -1,11 +1,11 @@
 use crate::{faker::boolean::en::Boolean, Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 
 impl<T, U> Dummy<U> for Option<T>
 where
     T: Dummy<U>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &U, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &U, rng: &mut R) -> Self {
         if Faker.fake_with_rng::<bool, _>(rng) {
             Some(T::dummy_with_rng(config, rng))
         } else {
@@ -30,7 +30,7 @@ impl<T, U> Dummy<Opt<U>> for Optional<T>
 where
     T: Dummy<U>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Opt<U>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Opt<U>, rng: &mut R) -> Self {
         if Boolean(config.1).fake_with_rng(rng) {
             Optional(Some(config.0.fake_with_rng(rng)))
         } else {

--- a/fake/src/impls/std/path.rs
+++ b/fake/src/impls/std/path.rs
@@ -1,7 +1,7 @@
 use crate::locales::{Data, EN};
 use crate::{Dummy, Fake, Faker};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 use std::path::PathBuf;
 
 static DEFAULT_PATH_FAKER: PathFaker = PathFaker {
@@ -13,7 +13,7 @@ static DEFAULT_PATH_FAKER: PathFaker = PathFaker {
 
 impl Dummy<Faker> for PathBuf {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         DEFAULT_PATH_FAKER.fake_with_rng(rng)
     }
 }
@@ -46,7 +46,7 @@ impl<'a> PathFaker<'a> {
 }
 
 impl<'a> Dummy<PathFaker<'a>> for PathBuf {
-    fn dummy_with_rng<R: Rng + ?Sized>(c: &PathFaker<'a>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(c: &PathFaker<'a>, rng: &mut R) -> Self {
         let root_dir = c.root_dirs.choose(rng).unwrap();
         let mut path = PathBuf::from(root_dir);
         for _ in 0..c.max_level {

--- a/fake/src/impls/std/primitives.rs
+++ b/fake/src/impls/std/primitives.rs
@@ -1,6 +1,6 @@
 use crate::{Dummy, Faker};
 use rand::distr::{Distribution, Uniform};
-use rand::Rng;
+use rand::RngExt;
 use std::ops;
 
 macro_rules! faker_impl {
@@ -10,13 +10,13 @@ macro_rules! faker_impl {
                 t.clone()
             }
 
-            fn dummy_with_rng<R: Rng + ?Sized>(t: &$typ, _rng: &mut R) -> Self {
+            fn dummy_with_rng<R: RngExt + ?Sized>(t: &$typ, _rng: &mut R) -> Self {
                 t.clone()
             }
         }
 
         impl Dummy<Faker> for $typ {
-            fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+            fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
                 rng.random()
             }
         }
@@ -28,13 +28,13 @@ impl Dummy<usize> for usize {
         *t
     }
 
-    fn dummy_with_rng<R: Rng + ?Sized>(t: &usize, _rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(t: &usize, _rng: &mut R) -> Self {
         *t
     }
 }
 
 impl Dummy<Faker> for usize {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         rng.random::<u64>() as usize
     }
 }
@@ -44,25 +44,25 @@ impl Dummy<isize> for isize {
         *t
     }
 
-    fn dummy_with_rng<R: Rng + ?Sized>(t: &isize, _rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(t: &isize, _rng: &mut R) -> Self {
         *t
     }
 }
 
 impl Dummy<Faker> for isize {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         rng.random::<i64>() as isize
     }
 }
 
 impl Dummy<Uniform<u64>> for usize {
-    fn dummy_with_rng<R: Rng + ?Sized>(dist: &Uniform<u64>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(dist: &Uniform<u64>, rng: &mut R) -> Self {
         dist.sample(rng) as usize
     }
 }
 
 impl Dummy<Uniform<i64>> for isize {
-    fn dummy_with_rng<R: Rng + ?Sized>(dist: &Uniform<i64>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(dist: &Uniform<i64>, rng: &mut R) -> Self {
         dist.sample(rng) as isize
     }
 }
@@ -70,27 +70,30 @@ impl Dummy<Uniform<i64>> for isize {
 macro_rules! range_impl {
     ($typ:ident) => {
         impl Dummy<ops::Range<Self>> for $typ {
-            fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::Range<Self>, rng: &mut R) -> Self {
+            fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::Range<Self>, rng: &mut R) -> Self {
                 rng.random_range(range.start..range.end)
             }
         }
 
         impl Dummy<ops::RangeFrom<Self>> for $typ {
-            fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeFrom<Self>, rng: &mut R) -> Self {
+            fn dummy_with_rng<R: RngExt + ?Sized>(
+                range: &ops::RangeFrom<Self>,
+                rng: &mut R,
+            ) -> Self {
                 let u = Uniform::new_inclusive(range.start, $typ::MAX).expect("Can sample uniform");
                 u.sample(rng)
             }
         }
 
         impl Dummy<ops::RangeFull> for $typ {
-            fn dummy_with_rng<R: Rng + ?Sized>(_: &ops::RangeFull, rng: &mut R) -> Self {
+            fn dummy_with_rng<R: RngExt + ?Sized>(_: &ops::RangeFull, rng: &mut R) -> Self {
                 let u = Uniform::new_inclusive($typ::MIN, $typ::MAX).expect("Can sample uniform");
                 u.sample(rng)
             }
         }
 
         impl Dummy<ops::RangeInclusive<Self>> for $typ {
-            fn dummy_with_rng<R: Rng + ?Sized>(
+            fn dummy_with_rng<R: RngExt + ?Sized>(
                 range: &ops::RangeInclusive<Self>,
                 rng: &mut R,
             ) -> Self {
@@ -101,13 +104,13 @@ macro_rules! range_impl {
         }
 
         impl Dummy<ops::RangeTo<Self>> for $typ {
-            fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeTo<Self>, rng: &mut R) -> Self {
+            fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::RangeTo<Self>, rng: &mut R) -> Self {
                 rng.random_range($typ::MIN..range.end)
             }
         }
 
         impl Dummy<ops::RangeToInclusive<Self>> for $typ {
-            fn dummy_with_rng<R: Rng + ?Sized>(
+            fn dummy_with_rng<R: RngExt + ?Sized>(
                 range: &ops::RangeToInclusive<Self>,
                 rng: &mut R,
             ) -> Self {
@@ -119,27 +122,27 @@ macro_rules! range_impl {
 }
 
 impl Dummy<ops::Range<Self>> for usize {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::Range<Self>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::Range<Self>, rng: &mut R) -> Self {
         rng.random_range(range.start..range.end)
     }
 }
 
 impl Dummy<ops::RangeFrom<Self>> for usize {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeFrom<Self>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::RangeFrom<Self>, rng: &mut R) -> Self {
         let u = Uniform::new_inclusive(range.start as u64, u64::MAX).expect("Can sample uniform");
         u.sample(rng) as usize
     }
 }
 
 impl Dummy<ops::RangeFull> for usize {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &ops::RangeFull, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &ops::RangeFull, rng: &mut R) -> Self {
         let u = Uniform::new_inclusive(u64::MIN, u64::MAX).expect("Can sample uniform");
         u.sample(rng) as usize
     }
 }
 
 impl Dummy<ops::RangeInclusive<Self>> for usize {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeInclusive<Self>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::RangeInclusive<Self>, rng: &mut R) -> Self {
         let u = Uniform::new_inclusive(*range.start() as u64, *range.end() as u64)
             .expect("Can sample uniform");
         u.sample(rng) as usize
@@ -147,40 +150,43 @@ impl Dummy<ops::RangeInclusive<Self>> for usize {
 }
 
 impl Dummy<ops::RangeTo<Self>> for usize {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeTo<Self>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::RangeTo<Self>, rng: &mut R) -> Self {
         rng.random_range(u64::MIN..range.end as u64) as usize
     }
 }
 
 impl Dummy<ops::RangeToInclusive<Self>> for usize {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeToInclusive<Self>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(
+        range: &ops::RangeToInclusive<Self>,
+        rng: &mut R,
+    ) -> Self {
         let u = Uniform::new_inclusive(u64::MIN, range.end as u64).expect("Can sample uniform");
         u.sample(rng) as usize
     }
 }
 
 impl Dummy<ops::Range<Self>> for isize {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::Range<Self>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::Range<Self>, rng: &mut R) -> Self {
         rng.random_range(range.start as i64..range.end as i64) as isize
     }
 }
 
 impl Dummy<ops::RangeFrom<Self>> for isize {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeFrom<Self>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::RangeFrom<Self>, rng: &mut R) -> Self {
         let u = Uniform::new_inclusive(range.start as i64, i64::MAX).expect("Can sample uniform");
         u.sample(rng) as isize
     }
 }
 
 impl Dummy<ops::RangeFull> for isize {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &ops::RangeFull, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &ops::RangeFull, rng: &mut R) -> Self {
         let u = Uniform::new_inclusive(i64::MIN, i64::MAX).expect("Can sample uniform");
         u.sample(rng) as isize
     }
 }
 
 impl Dummy<ops::RangeInclusive<Self>> for isize {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeInclusive<Self>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::RangeInclusive<Self>, rng: &mut R) -> Self {
         let u = Uniform::new_inclusive(*range.start() as i64, *range.end() as i64)
             .expect("Can sample uniform");
         u.sample(rng) as isize
@@ -188,13 +194,16 @@ impl Dummy<ops::RangeInclusive<Self>> for isize {
 }
 
 impl Dummy<ops::RangeTo<Self>> for isize {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeTo<Self>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::RangeTo<Self>, rng: &mut R) -> Self {
         rng.random_range(i64::MIN..range.end as i64) as isize
     }
 }
 
 impl Dummy<ops::RangeToInclusive<Self>> for isize {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeToInclusive<Self>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(
+        range: &ops::RangeToInclusive<Self>,
+        rng: &mut R,
+    ) -> Self {
         let u = Uniform::new_inclusive(i64::MIN, range.end as i64).expect("Can sample uniform");
         u.sample(rng) as isize
     }
@@ -203,7 +212,7 @@ impl Dummy<ops::RangeToInclusive<Self>> for isize {
 macro_rules! number_impl {
     ($typ:ident) => {
         impl Dummy<Uniform<Self>> for $typ {
-            fn dummy_with_rng<R: Rng + ?Sized>(dist: &Uniform<Self>, rng: &mut R) -> Self {
+            fn dummy_with_rng<R: RngExt + ?Sized>(dist: &Uniform<Self>, rng: &mut R) -> Self {
                 dist.sample(rng)
             }
         }

--- a/fake/src/impls/std/result.rs
+++ b/fake/src/impls/std/result.rs
@@ -1,12 +1,12 @@
 use crate::{faker::boolean::en::Boolean, Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 
 impl<T, E> Dummy<Faker> for Result<T, E>
 where
     T: Dummy<Faker>,
     E: Dummy<Faker>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
         if Faker.fake_with_rng::<bool, _>(rng) {
             Ok(T::dummy_with_rng(config, rng))
         } else {
@@ -91,7 +91,7 @@ where
     E: Dummy<V>,
     u8: Dummy<X>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &ResultFaker<U, V, X>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &ResultFaker<U, V, X>, rng: &mut R) -> Self {
         if Boolean(config.err_rate.fake_with_rng(rng)).fake_with_rng::<bool, _>(rng) {
             Err(E::dummy_with_rng(&config.err, rng))
         } else {

--- a/fake/src/impls/std/string.rs
+++ b/fake/src/impls/std/string.rs
@@ -1,13 +1,13 @@
 use crate::{Dummy, Fake, Faker};
 use rand::distr::Alphanumeric;
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 use std::ops;
 
 const DEFAULT_STR_LEN_RANGE: ops::Range<usize> = 5..20;
 
 impl Dummy<usize> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(len: &usize, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(len: &usize, rng: &mut R) -> Self {
         rng.sample_iter(&Alphanumeric)
             .take(*len)
             .map(char::from)
@@ -16,49 +16,52 @@ impl Dummy<usize> for String {
 }
 
 impl Dummy<Faker> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let len: usize = DEFAULT_STR_LEN_RANGE.fake_with_rng(rng);
         len.fake_with_rng(rng)
     }
 }
 
 impl Dummy<ops::Range<usize>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::Range<usize>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::Range<usize>, rng: &mut R) -> Self {
         let len: usize = range.fake_with_rng(rng);
         len.fake_with_rng(rng)
     }
 }
 
 impl Dummy<ops::RangeFrom<usize>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeFrom<usize>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::RangeFrom<usize>, rng: &mut R) -> Self {
         let len: usize = range.fake_with_rng(rng);
         len.fake_with_rng(rng)
     }
 }
 
 impl Dummy<ops::RangeFull> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeFull, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::RangeFull, rng: &mut R) -> Self {
         let len: usize = range.fake_with_rng(rng);
         len.fake_with_rng(rng)
     }
 }
 
 impl Dummy<ops::RangeInclusive<usize>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeInclusive<usize>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::RangeInclusive<usize>, rng: &mut R) -> Self {
         let len: usize = range.fake_with_rng(rng);
         len.fake_with_rng(rng)
     }
 }
 
 impl Dummy<ops::RangeTo<usize>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeTo<usize>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(range: &ops::RangeTo<usize>, rng: &mut R) -> Self {
         let len: usize = range.fake_with_rng(rng);
         len.fake_with_rng(rng)
     }
 }
 
 impl Dummy<ops::RangeToInclusive<usize>> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(range: &ops::RangeToInclusive<usize>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(
+        range: &ops::RangeToInclusive<usize>,
+        rng: &mut R,
+    ) -> Self {
         let len: usize = range.fake_with_rng(rng);
         len.fake_with_rng(rng)
     }
@@ -101,7 +104,7 @@ impl<L> Dummy<StringFaker<L>> for String
 where
     usize: Dummy<L>,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &StringFaker<L>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &StringFaker<L>, rng: &mut R) -> Self {
         let len: usize = config.len.fake_with_rng(rng);
         let s: Option<String> = (0..len)
             .map(|_| Some(*config.charset.choose(rng)? as char))

--- a/fake/src/impls/std/time.rs
+++ b/fake/src/impls/std/time.rs
@@ -1,11 +1,11 @@
 use std::time::Duration;
 
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 
 impl Dummy<Faker> for Duration {
     #[inline]
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         Duration::from_nanos(Faker.fake_with_rng(rng))
     }
 }

--- a/fake/src/impls/std/tuple.rs
+++ b/fake/src/impls/std/tuple.rs
@@ -1,5 +1,5 @@
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 
 macro_rules! tuple_impl {
     ($(
@@ -10,14 +10,14 @@ macro_rules! tuple_impl {
         $(
             impl<$($T:Dummy<Faker>),+> Dummy<Faker> for ($($T,)+) {
                 #[inline]
-                fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+                fn dummy_with_rng<R: RngExt + ?Sized>(config: &Faker, rng: &mut R) -> Self {
                     ($({ let x: $T = config.fake_with_rng(rng); x},)+)
                 }
             }
 
             impl<$($U, $T:Dummy<$U>),+> Dummy<($($U,)+)> for ($($T,)+) {
                 #[inline]
-                fn dummy_with_rng<R: Rng + ?Sized>(config: &($($U,)+), rng: &mut R) -> Self {
+                fn dummy_with_rng<R: RngExt + ?Sized>(config: &($($U,)+), rng: &mut R) -> Self {
                     ($({ let x: $T = config.$idx.fake_with_rng(rng); x},)+)
                 }
             }

--- a/fake/src/impls/time/mod.rs
+++ b/fake/src/impls/time/mod.rs
@@ -1,5 +1,5 @@
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 use time::{Date, Duration, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
 
 const YEAR_MAG: i32 = 3_000i32;
@@ -15,13 +15,13 @@ fn is_leap(year: i32) -> bool {
 }
 
 impl Dummy<Faker> for Duration {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         Duration::nanoseconds(Faker.fake_with_rng(rng))
     }
 }
 
 impl Dummy<Faker> for UtcOffset {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         // UtcOffset ±25:59:59
         let seconds: i32 = (-93599..93599).fake_with_rng(rng);
         UtcOffset::from_whole_seconds(seconds).unwrap()
@@ -29,7 +29,7 @@ impl Dummy<Faker> for UtcOffset {
 }
 
 impl Dummy<Faker> for OffsetDateTime {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let date = Faker.fake_with_rng(rng);
         let time = Faker.fake_with_rng(rng);
         let offset = Faker.fake_with_rng(rng);
@@ -38,7 +38,7 @@ impl Dummy<Faker> for OffsetDateTime {
 }
 
 impl Dummy<Faker> for Date {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let year: i32 = (0..YEAR_MAG).fake_with_rng(rng);
         let end = if is_leap(year) { 366 } else { 365 };
         let day_ord: u16 = (1..end).fake_with_rng(rng);
@@ -47,7 +47,7 @@ impl Dummy<Faker> for Date {
 }
 
 impl Dummy<Faker> for Time {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let hour = (0..24).fake_with_rng(rng);
         let min = (0..60).fake_with_rng(rng);
         let sec = (0..60).fake_with_rng(rng);
@@ -56,7 +56,7 @@ impl Dummy<Faker> for Time {
 }
 
 impl Dummy<Faker> for PrimitiveDateTime {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let date = Faker.fake_with_rng(rng);
         let time = Faker.fake_with_rng(rng);
         PrimitiveDateTime::new(date, time)
@@ -91,7 +91,7 @@ impl<const N: usize> Dummy<Precision<N>> for Time
 where
     Precision<N>: AllowedPrecision,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Precision<N>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Precision<N>, rng: &mut R) -> Self {
         let time: Time = Faker.fake_with_rng(rng);
         time.replace_nanosecond(Precision::<N>::to_scale(time.nanosecond()))
             .expect("failed to create time")
@@ -102,7 +102,7 @@ impl<const N: usize> Dummy<Precision<N>> for PrimitiveDateTime
 where
     Precision<N>: AllowedPrecision,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Precision<N>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Precision<N>, rng: &mut R) -> Self {
         let date = Faker.fake_with_rng(rng);
         let time = Precision::<N>.fake_with_rng(rng);
         PrimitiveDateTime::new(date, time)
@@ -113,7 +113,7 @@ impl<const N: usize> Dummy<Precision<N>> for OffsetDateTime
 where
     Precision<N>: AllowedPrecision,
 {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Precision<N>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Precision<N>, rng: &mut R) -> Self {
         let time: OffsetDateTime = Faker.fake_with_rng(rng);
         time.replace_nanosecond(Precision::<N>::to_scale(time.nanosecond()))
             .expect("failed to create time")

--- a/fake/src/impls/ulid/mod.rs
+++ b/fake/src/impls/ulid/mod.rs
@@ -5,7 +5,7 @@ use ulid::Ulid;
 use crate::{Dummy, Faker};
 
 impl Dummy<Faker> for Ulid {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let time_part: u64 = rng.random_range(0..(1 << Ulid::TIME_BITS));
         let rand_part: u128 = rng.random_range(0..(1 << Ulid::RAND_BITS));
         Ulid::from_parts(time_part, rand_part)

--- a/fake/src/impls/url/mod.rs
+++ b/fake/src/impls/url/mod.rs
@@ -1,6 +1,6 @@
 use crate::{Dummy, Faker};
 use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::RngExt;
 use url::Url;
 
 const FQDN: &str = "https://example.com";
@@ -38,7 +38,7 @@ const PATHS: [&str; 30] = [
 ];
 
 impl Dummy<Faker> for Url {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         let path: &str = PATHS.choose(rng).unwrap();
         Url::parse(&format!("{FQDN}{path}")).unwrap()
     }

--- a/fake/src/impls/uuid/mod.rs
+++ b/fake/src/impls/uuid/mod.rs
@@ -44,7 +44,7 @@ pub struct UUIDv7;
 pub struct UUIDv8;
 
 impl Dummy<UUIDv1> for Uuid {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &UUIDv1, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &UUIDv1, rng: &mut R) -> Self {
         let ticks = rng.random_range(uuid::timestamp::UUID_TICKS_BETWEEN_EPOCHS..u64::MAX);
         let counter = Faker.fake_with_rng(rng);
         let ts = uuid::timestamp::Timestamp::from_gregorian(ticks, counter);
@@ -54,13 +54,13 @@ impl Dummy<UUIDv1> for Uuid {
 }
 
 impl Dummy<UUIDv1> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &UUIDv1, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &UUIDv1, rng: &mut R) -> Self {
         Uuid::dummy_with_rng(config, rng).hyphenated().to_string()
     }
 }
 
 impl Dummy<UUIDv3> for Uuid {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &UUIDv3, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &UUIDv3, rng: &mut R) -> Self {
         Builder::from_bytes(rng.random())
             .with_variant(Variant::RFC4122)
             .with_version(Version::Md5)
@@ -69,13 +69,13 @@ impl Dummy<UUIDv3> for Uuid {
 }
 
 impl Dummy<UUIDv3> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &UUIDv3, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &UUIDv3, rng: &mut R) -> Self {
         Uuid::dummy_with_rng(config, rng).hyphenated().to_string()
     }
 }
 
 impl Dummy<UUIDv4> for Uuid {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &UUIDv4, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &UUIDv4, rng: &mut R) -> Self {
         Builder::from_bytes(rng.random())
             .with_variant(Variant::RFC4122)
             .with_version(Version::Random)
@@ -84,13 +84,13 @@ impl Dummy<UUIDv4> for Uuid {
 }
 
 impl Dummy<UUIDv4> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &UUIDv4, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &UUIDv4, rng: &mut R) -> Self {
         Uuid::dummy_with_rng(config, rng).hyphenated().to_string()
     }
 }
 
 impl Dummy<UUIDv5> for Uuid {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &UUIDv5, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &UUIDv5, rng: &mut R) -> Self {
         Builder::from_bytes(rng.random())
             .with_variant(Variant::RFC4122)
             .with_version(Version::Sha1)
@@ -99,13 +99,13 @@ impl Dummy<UUIDv5> for Uuid {
 }
 
 impl Dummy<UUIDv5> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &UUIDv5, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &UUIDv5, rng: &mut R) -> Self {
         Uuid::dummy_with_rng(config, rng).hyphenated().to_string()
     }
 }
 
 impl Dummy<UUIDv6> for Uuid {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &UUIDv6, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &UUIDv6, rng: &mut R) -> Self {
         let ticks = rng.random_range(uuid::timestamp::UUID_TICKS_BETWEEN_EPOCHS..u64::MAX);
         let counter = Faker.fake_with_rng(rng);
         let ts = uuid::timestamp::Timestamp::from_gregorian(ticks, counter);
@@ -115,13 +115,13 @@ impl Dummy<UUIDv6> for Uuid {
 }
 
 impl Dummy<UUIDv6> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &UUIDv6, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &UUIDv6, rng: &mut R) -> Self {
         Uuid::dummy_with_rng(config, rng).hyphenated().to_string()
     }
 }
 
 impl Dummy<UUIDv7> for Uuid {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &UUIDv7, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &UUIDv7, rng: &mut R) -> Self {
         let ticks = rng.random_range(uuid::timestamp::UUID_TICKS_BETWEEN_EPOCHS..u64::MAX);
         let counter = Faker.fake_with_rng(rng);
         let ts = uuid::timestamp::Timestamp::from_gregorian(ticks, counter);
@@ -130,26 +130,26 @@ impl Dummy<UUIDv7> for Uuid {
 }
 
 impl Dummy<UUIDv7> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &UUIDv7, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &UUIDv7, rng: &mut R) -> Self {
         Uuid::dummy_with_rng(config, rng).hyphenated().to_string()
     }
 }
 
 impl Dummy<UUIDv8> for Uuid {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &UUIDv8, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &UUIDv8, rng: &mut R) -> Self {
         let buf: [u8; 16] = Faker.fake_with_rng(rng);
         Uuid::new_v8(buf)
     }
 }
 
 impl Dummy<UUIDv8> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &UUIDv8, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(config: &UUIDv8, rng: &mut R) -> Self {
         Uuid::dummy_with_rng(config, rng).hyphenated().to_string()
     }
 }
 
 impl Dummy<Faker> for Uuid {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
         Uuid::from_u128(rng.random())
     }
 }

--- a/fake/src/impls/zerocopy_byteorder/mod.rs
+++ b/fake/src/impls/zerocopy_byteorder/mod.rs
@@ -1,11 +1,11 @@
 use crate::{Dummy, Fake, Faker};
-use rand::Rng;
+use rand::RngExt;
 use zerocopy::{byteorder, ByteOrder};
 
 macro_rules! byteorder_faker_impl {
     ($typ:ident) => {
         impl<O: ByteOrder> Dummy<Faker> for byteorder::$typ<O> {
-            fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+            fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
                 Self::new(Faker.fake_with_rng(rng))
             }
         }

--- a/fake/src/lib.rs
+++ b/fake/src/lib.rs
@@ -94,7 +94,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use rand;
-pub use rand::Rng;
+pub use rand::RngExt;
 
 /// Generate default fake value for given type using [`Fake`].
 ///
@@ -131,12 +131,12 @@ pub struct Faker;
 ///
 /// ```
 /// use fake::rand::prelude::IndexedRandom;
-/// use fake::{Dummy, Fake, Faker, Rng};
+/// use fake::{Dummy, Fake, Faker, RngExt};
 ///
 /// struct Name; // does not handle locale, see locales module for more
 ///
 /// impl Dummy<Name> for &'static str {
-///     fn dummy_with_rng<R: Rng + ?Sized>(_: &Name, rng: &mut R) -> &'static str {
+///     fn dummy_with_rng<R: RngExt + ?Sized>(_: &Name, rng: &mut R) -> &'static str {
 ///         const NAMES: &[&str] = &["John Doe", "Jane Doe"];
 ///         NAMES.choose(rng).unwrap()
 ///     }
@@ -162,13 +162,13 @@ pub trait Dummy<T>: Sized {
 
     /// Generate a dummy value for a given type using a random number
     /// generator.
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &T, rng: &mut R) -> Self;
+    fn dummy_with_rng<R: RngExt + ?Sized>(config: &T, rng: &mut R) -> Self;
 }
 
 mod private {
     pub trait FakeBase<T>: Sized {
         fn _fake(&self) -> T;
-        fn _fake_with_rng<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> T;
+        fn _fake_with_rng<R: rand::RngExt + ?Sized>(&self, rng: &mut R) -> T;
     }
 
     impl<T, U> FakeBase<U> for T
@@ -179,7 +179,7 @@ mod private {
             U::dummy(self)
         }
 
-        fn _fake_with_rng<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> U {
+        fn _fake_with_rng<R: rand::RngExt + ?Sized>(&self, rng: &mut R) -> U {
             U::dummy_with_rng(self, rng)
         }
     }
@@ -217,7 +217,7 @@ pub trait Fake: Sized {
     }
 
     #[inline]
-    fn fake_with_rng<U, R: Rng + ?Sized>(&self, rng: &mut R) -> U
+    fn fake_with_rng<U, R: RngExt + ?Sized>(&self, rng: &mut R) -> U
     where
         Self: private::FakeBase<U>,
     {
@@ -228,7 +228,7 @@ impl<T> Fake for T {}
 
 #[cfg(feature = "geo")]
 #[cfg_attr(docsrs, doc(cfg(feature = "geo")))]
-fn unique<U: Dummy<Faker> + PartialEq, R: Rng + ?Sized>(rng: &mut R, len: usize) -> Vec<U> {
+fn unique<U: Dummy<Faker> + PartialEq, R: RngExt + ?Sized>(rng: &mut R, len: usize) -> Vec<U> {
     let mut set = Vec::<U>::new();
     unique_append(&mut set, rng, len);
     set
@@ -236,7 +236,7 @@ fn unique<U: Dummy<Faker> + PartialEq, R: Rng + ?Sized>(rng: &mut R, len: usize)
 
 #[cfg(feature = "geo")]
 #[cfg_attr(docsrs, doc(cfg(feature = "geo")))]
-fn unique_append<U: Dummy<Faker> + PartialEq, R: Rng + ?Sized>(
+fn unique_append<U: Dummy<Faker> + PartialEq, R: RngExt + ?Sized>(
     set: &mut Vec<U>,
     rng: &mut R,
     len: usize,
@@ -371,7 +371,7 @@ pub mod locales;
 /// This would generate code roughly equivalent to:
 ///
 /// ```
-/// use fake::{Dummy, Fake, Faker, Rng};
+/// use fake::{Dummy, Fake, Faker, RngExt};
 /// use fake::faker::name::en::Name;
 ///
 /// pub struct Foo {
@@ -383,7 +383,7 @@ pub mod locales;
 /// }
 ///
 /// impl Dummy<Faker> for Foo {
-///     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+///     fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
 ///         let order_id = Fake::fake_with_rng::<usize, _>(&(1000..2000), rng);
 ///         let customer = Fake::fake_with_rng::<String, _>(&(Name()), rng);
 ///         let paid = Fake::fake_with_rng::<bool, _>(&Faker, rng);
@@ -427,7 +427,7 @@ pub mod locales;
 /// This will generate code roughly equivalent to:
 ///
 /// ```
-/// use fake::{Dummy, Fake, Faker, Rng};
+/// use fake::{Dummy, Fake, Faker, RngExt};
 /// use fake::faker::name::en::Name;
 ///
 /// pub enum Bar {
@@ -440,7 +440,7 @@ pub mod locales;
 /// }
 ///
 /// impl Dummy<Faker> for Bar {
-///     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+///     fn dummy_with_rng<R: RngExt + ?Sized>(_: &Faker, rng: &mut R) -> Self {
 ///         match rng.random_range(0..3usize) {
 ///             0 => Self::Simple,
 ///             1 => Self::Tuple(Fake::fake_with_rng::<i32, _>(&(0..5), rng)),

--- a/fake/src/locales/de_de.rs
+++ b/fake/src/locales/de_de.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 
 use crate::{
     faker::{
@@ -311,7 +311,7 @@ impl Data for DE_DE {
 }
 
 impl CityNameGenFn for DE_DE {
-    fn gen<R: Rng + ?Sized>(c: &CityName<Self>, rng: &mut R) -> String {
+    fn gen<R: RngExt + ?Sized>(c: &CityName<Self>, rng: &mut R) -> String {
         // german cities are often suffixed by a river name
         const RIVERS: [&str; 10] = [
             "(Rhein)", "(Elbe)", "(Donau)", "(Main)", "(Weser)", "(Oder)", "(Neckar)", "(Havel)",

--- a/fake/src/locales/fa_ir.rs
+++ b/fake/src/locales/fa_ir.rs
@@ -1078,7 +1078,7 @@ impl CityNameGenFn for FA_IR {}
 const LICENSE_PLATE_FA_IR: &[&str] = &["## ABC ###", "## AB ####"];
 
 impl Dummy<LicencePlate<FA_IR>> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &LicencePlate<FA_IR>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &LicencePlate<FA_IR>, rng: &mut R) -> Self {
         let fmt = LICENSE_PLATE_FA_IR.choose(rng).unwrap();
         crate::faker::impls::automotive::numerify_licence_plate(fmt, rng)
     }

--- a/fake/src/locales/nl_nl.rs
+++ b/fake/src/locales/nl_nl.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 
 use crate::{
     faker::{
@@ -552,7 +552,7 @@ impl Data for NL_NL {
 }
 
 impl CityNameGenFn for NL_NL {
-    fn gen<R: Rng + ?Sized>(c: &CityName<Self>, rng: &mut R) -> String {
+    fn gen<R: RngExt + ?Sized>(c: &CityName<Self>, rng: &mut R) -> String {
         // common formats for city names
         const ADDRESS_CITY_WITHOUT_PREFIX: &str = "{CityName}{CitySuffix}";
         const ADDRESS_CITY_WITHOUT_SPACE: &str = "{CityPrefix}{CityName}{CitySuffix}";

--- a/fake/src/locales/pt_pt.rs
+++ b/fake/src/locales/pt_pt.rs
@@ -832,7 +832,7 @@ const LICENSE_PLATE_PT_PT: &[&str] = &[
 ];
 
 impl Dummy<LicencePlate<PT_PT>> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &LicencePlate<PT_PT>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &LicencePlate<PT_PT>, rng: &mut R) -> Self {
         let fmt = LICENSE_PLATE_PT_PT.choose(rng).unwrap();
         crate::faker::impls::automotive::numerify_licence_plate(fmt, rng)
     }

--- a/fake/src/locales/tr_tr.rs
+++ b/fake/src/locales/tr_tr.rs
@@ -225,7 +225,7 @@ impl CityNameGenFn for TR_TR {}
 const LICENSE_PLATE_TR_TR: &[&str] = &["## ABC ###", "## AB ####"];
 
 impl Dummy<LicencePlate<TR_TR>> for String {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &LicencePlate<TR_TR>, rng: &mut R) -> Self {
+    fn dummy_with_rng<R: rand::RngExt + ?Sized>(_: &LicencePlate<TR_TR>, rng: &mut R) -> Self {
         let fmt = LICENSE_PLATE_TR_TR.choose(rng).unwrap();
         crate::faker::impls::automotive::numerify_licence_plate(fmt, rng)
     }

--- a/fake/tests/always-true.rs
+++ b/fake/tests/always-true.rs
@@ -6,7 +6,7 @@ mod always_true_tests {
     #[test]
     fn test_rng_bool() {
         use rand::distr::StandardUniform;
-        use rand::Rng;
+        use rand::RngExt;
         // Arrange
         let rng = AlwaysTrueRng::default();
 
@@ -19,7 +19,7 @@ mod always_true_tests {
 
     #[test]
     fn test_rng_bool_wrap_large_increment() {
-        use rand::{distr::StandardUniform, Rng};
+        use rand::{distr::StandardUniform, RngExt};
         let increment = 1 << 31;
 
         // Arrange
@@ -38,7 +38,7 @@ mod always_true_tests {
 
     #[test]
     fn test_rng_int() {
-        use rand::{distr::StandardUniform, Rng};
+        use rand::{distr::StandardUniform, RngExt};
 
         // Arrange
         let rng = AlwaysTrueRng::default();
@@ -62,7 +62,7 @@ mod always_true_tests {
 
     #[test]
     fn test_rng_int_wrap() {
-        use rand::{distr::StandardUniform, Rng};
+        use rand::{distr::StandardUniform, RngExt};
 
         // Arrange
         let increment = 1 << 31;

--- a/fake/tests/derive_macros.rs
+++ b/fake/tests/derive_macros.rs
@@ -1,14 +1,14 @@
 use fake::{Dummy, Fake, Faker};
 use rand::SeedableRng;
 
-fn rng() -> rand_chacha::ChaCha20Rng {
+fn rng() -> rand::rngs::ChaCha20Rng {
     // Fixing the RNG So we have more deterministic tests
     // as we are only testing the derive macros, not the RNG
     let seed = [
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0,
     ];
-    rand_chacha::ChaCha20Rng::from_seed(seed)
+    rand::rngs::ChaCha20Rng::from_seed(seed)
 }
 
 mod field_options {

--- a/fake/tests/determinism.rs
+++ b/fake/tests/determinism.rs
@@ -18,8 +18,8 @@ macro_rules! determinism_test {
             #[allow(unused_parens)]
             #[test]
             fn $name(seed: [u8; 32]) {
-                let mut rng1 = rand_chacha::ChaCha20Rng::from_seed(seed);
-                let mut rng2 = rng1.clone();
+                let mut rng1 = rand::rngs::ChaCha20Rng::from_seed(seed);
+                let mut rng2 = rand::rngs::ChaCha20Rng::from_seed(seed);
 
                 for _ in 0..16 {
                     let val1: $ty = $op.fake_with_rng(&mut rng1);


### PR DESCRIPTION
0.10 changelog:

- Rename Rng -> RngExt
- Rename fn IndexedRandom::choose_multiple -> sample
- The dependency on rand_chacha has been replaced with a dependency on chacha20. This changes the implementation behind StdRng, but the output remains the same. There may be some API breakage when using the ChaCha-types directly as these are now the ones in chacha20 instead of rand_chacha