### PR TITLE
feat: localize company names for fr_FR

### DIFF
--- a/fake/src/locales/fr_fr.rs
+++ b/fake/src/locales/fr_fr.rs
@@ -1910,6 +1910,12 @@ impl Data for FR_FR {
 
     const NAME_TITLE: &'static [&'static str] = &["Mme", "M."];
 
+    const COMPANY_SUFFIX: &'static [&'static str] =
+        &["SARL", "SA", "SAS", "EURL", "et Fils", "et Cie"];
+
+    const COMPANY_NAME_TPLS: &'static [&'static str] =
+        &["{Name_1} {Suffix}", "{Name_1} et {Name_2} {Suffix}"];
+
     const ADDRESS_CITY_TPL: &'static str = "{CityName}";
 
     const ADDRESS_STREET_SUFFIX: &'static [&'static str] = &[


### PR DESCRIPTION
`FR_FR` company names fall back to the English defaults, e.g.
`Lefebvre and Sons` or `Dubois and Durand LLC`.

Motivation: postgresql_anonymizer uses fake-rs for its localized fake
data, and French company names were coming out anglicised.
